### PR TITLE
added missing roles attributes to directory.ts and minor cleanup

### DIFF
--- a/interop/authzen-todo-backend/src/directory.ts
+++ b/interop/authzen-todo-backend/src/directory.ts
@@ -2,63 +2,73 @@ import { User } from "./interfaces";
 
 const users = {
   "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
-      "key": "rick@the-citadel.com",
-      "name": "Rick Sanchez",
-      "email": "rick@the-citadel.com",
-      "picture": "https://www.topaz.sh/assets/templates/citadel/img/Rick%20Sanchez.jpg"
-  },
-  "rick@the-citadel.com": {
-    "key": "rick@the-citadel.com",
+    "id": "rick@the-citadel.com",
     "name": "Rick Sanchez",
     "email": "rick@the-citadel.com",
+    "roles": ["admin", "evil_genius"],
+    "picture": "https://www.topaz.sh/assets/templates/citadel/img/Rick%20Sanchez.jpg"
+  },
+  "rick@the-citadel.com": {
+    "id": "rick@the-citadel.com",
+    "name": "Rick Sanchez",
+    "email": "rick@the-citadel.com",
+    "roles": ["admin", "evil_genius"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Rick%20Sanchez.jpg"
   },
   "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
-    "key": "beth@the-smiths.com",
+    "id": "beth@the-smiths.com",
     "name": "Beth Smith",
     "email": "beth@the-smiths.com",
+    "roles": ["viewer"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Beth%20Smith.jpg"
   },
   "beth@the-smiths.com": {
-    "key": "beth@the-smiths.com",
+    "id": "beth@the-smiths.com",
     "name": "Beth Smith",
     "email": "beth@the-smiths.com",
+    "roles": ["viewer"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Beth%20Smith.jpg"
   },
   "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
-    "key": "morty@the-citadel.com",
+    "id": "morty@the-citadel.com",
     "name": "Morty Smith",
     "email": "morty@the-citadel.com",
+    "roles": ["editor"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Morty%20Smith.jpg"
   },
   "morty@the-citadel.com": {
-    "key": "morty@the-citadel.com",
+    "id": "morty@the-citadel.com",
     "name": "Morty Smith",
     "email": "morty@the-citadel.com",
+    "roles": ["editor"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Morty%20Smith.jpg"
   },
   "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
-    "key": "summer@the-smiths.com",
+    "id": "summer@the-smiths.com",
     "name": "Summer Smith",
     "email": "summer@the-smiths.com",
+    "roles": ["editor"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Summer%20Smith.jpg"
   },
   "summer@the-smiths.com": {
-    "key": "summer@the-smiths.com",
+    "id": "summer@the-smiths.com",
     "name": "Summer Smith",
     "email": "summer@the-smiths.com",
+    "roles": ["editor"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Summer%20Smith.jpg"
   },
   "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
-    "key": "jerry@the-smiths.com",
+    "id": "jerry@the-smiths.com",
     "name": "Jerry Smith",
     "email": "jerry@the-smiths.com",
-    "pict,ure": "https://www.topaz.sh/assets/templates/citadel/img/Jerry%20Smith.jpg"
+    "roles": ["viewer"],
+    "picture": "https://www.topaz.sh/assets/templates/citadel/img/Jerry%20Smith.jpg"
   },
   "jerry@the-smiths.com": {
-    "key": "jerry@the-smiths.com",
+    "id": "jerry@the-smiths.com",
     "name": "Jerry Smith",
     "email": "jerry@the-smiths.com",
+    "roles": ["viewer"],
     "picture": "https://www.topaz.sh/assets/templates/citadel/img/Jerry%20Smith.jpg"
   }
 }

--- a/interop/authzen-todo-backend/src/interfaces.d.ts
+++ b/interop/authzen-todo-backend/src/interfaces.d.ts
@@ -6,11 +6,11 @@ export interface Todo {
 }
 
 export interface User {
-  key: string;
+  id: string;
   email: string;
   picture: string;
   name: string;
 }
 export interface UserCache {
-  [key: string]: User;
+  [id: string]: User;
 }

--- a/interop/authzen-todo-backend/src/server.ts
+++ b/interop/authzen-todo-backend/src/server.ts
@@ -38,7 +38,7 @@ export class Server {
     todo.ID = uuidv4();
     try {
       const user = await this.directory.getUserByIdentity(req.auth.sub);
-      todo.OwnerID = user.key
+      todo.OwnerID = user.id;
 
       await this.store.insert(todo);
       res.json({ msg: "Todo created" });


### PR DESCRIPTION
Changes to the `authzen-todo-backend` sub-repo:
* added `roles` attribute to the json in `directory.ts`
* changed the `"key"` key to `"id"`, to match up with what's in the interop payload document
