### PR TITLE
updated test script to use AUTHZEN_PDP_API_KEY

### DIFF
--- a/interop/authzen-todo-backend/scripts/test.sh
+++ b/interop/authzen-todo-backend/scripts/test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 AUTHZEN_PDP_URL=${1:-https://authzen-proxy.demo.aserto.com}
-
 NO_COLOR='\033[0m'
 OK_COLOR='\033[32;01m'
 ERR_COLOR='\033[31;01m'
@@ -12,8 +11,7 @@ cat test/decisions.json | jq -c '.decisions[] ' | (
     while read BODY; do
         REQ=$(echo $BODY | jq '.request')
         EXP=$(echo $BODY | jq '.expected')
-        RSP=$(curl -s -H "content-type:application/json" -d "${REQ}" ${AUTHZEN_PDP_URL}/access/v1/evaluation | jq '.decision // false')
-        
+        RSP=$(curl -s -H "Authorization: ${AUTHZEN_PDP_API_KEY}" -H 'content-type:application/json' -d "${REQ}" ${AUTHZEN_PDP_URL}/access/v1/evaluation | jq '.decision // false')
         if [ "$EXP" = "$RSP" ]; then
             echo -e "${OK_COLOR}PASS${NO_COLOR} REQ:$(echo ${REQ} | jq -c .)"
         else


### PR DESCRIPTION
In `interop/authzen-todo-backend`, the `scripts/test.sh` bash script did not use the `AUTHZEN_PDP_API_KEY` environment variable. This PR fixes it.
