### PR TITLE
refactor API spec to remove search and boxcarred apis and cleanup

### DIFF
--- a/api/authorization-api-1_0-original.md
+++ b/api/authorization-api-1_0-original.md
@@ -106,7 +106,7 @@ This document describes the API version 1. Any updates to this API through subse
 A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked, or the Subject may be of interest in a Search API call.
 
 A Subject is a JSON ({{RFC8259}}) object that contains any number of key-value pair attributes e.g. 
-~~~json
+~~~ json
 "username" : "Alice",
 "department": "Sales"
 ~~~
@@ -155,7 +155,7 @@ type:
 
 The following is a non-normative example of a Resource:
 
-~~~json
+~~~ json
 {
   "id": "123",
   "type": "book",
@@ -197,7 +197,7 @@ The request follows a format similar to that used in XACML-JSON (TBD add normati
 
 #### Example (non-normative)
 
-~~~json
+~~~ json
 {
   "subject":{
     "id": {
@@ -275,7 +275,7 @@ reason_user:
 
 The following is a non-normative example of a Reason Object:
 
-~~~json
+~~~ json
 {
   "id": 0,
   "reason_admin": {
@@ -291,7 +291,7 @@ The following is a non-normative example of a Reason Object:
 
 #### Sample Response with additional context (non-normative)
 
-~~~json
+~~~ json
 {
   "decision": true,
   "context": {

--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -19,6 +19,7 @@ kw:
   - Cedar
   - PDP
   - PEP
+  - ALFA
 # date: 2022-02-02 -- date is filled in automatically by xml2rfc if not given
 author:
 - role: editor # remove if not true
@@ -103,9 +104,32 @@ A Subject is a JSON ({{RFC8259}}) object that contains any number of key-value p
 `id`:
 : REQUIRED. The unique identifier of the Subject, scoped to the `type`, within the scope of the PEP. If specified, the value MUST follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
 
-A Subject MUST minimally contain a `type` and an `id`, and MAY contain any number of additional fields.
+A Subject MUST minimally contain a `type` and an `id`, and MAY contain zero or more additional fields.
 
 The following is a non-normative example of a subject:
+
+~~~ json
+{
+  "type": "user",
+  "id": "alice@acmecorp.com"
+}
+~~~
+{: #subject-example title="Example Subject"}
+
+#### Subject Identifier {#subject-identifier}
+The `id` field of a Subject MAY be any valid JSON value. It MAY be a string, or it MAY be a structured identifier. For example, it MAY follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
+
+The following is a non-normative example of a subject identifier as a simple string:
+
+~~~ json
+{
+  "type": "user",
+  "id": "alice@acmecorp.com"
+}
+~~~
+{: #subject-identifier-example-simple title="Example of Simple Subject Identifier"}
+
+The following is a non-normative example of a Subject Identifier in the {{RFC9493}} Email Identifier Format:
 
 ~~~ json
 {
@@ -116,39 +140,36 @@ The following is a non-normative example of a subject:
   }
 }
 ~~~
-{: #subject-example title="Example Subject"}
-
-#### Subject Identifier {#subject-identifier}
-The `id` field of a Subject MUST follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}. A Subject MUST include at least one identifier, but MAY include more than one identifier if the format of the field is of type `aliases`.
-
-The following is a non-normative example of a Subject Identifier in the Email Identifier Format:
-
-~~~ json
-{
-  "format" : "email",
-  "email": "alice@acmecorp.com"
-}
-~~~
-{: #subject-identifier-example title="Example Subject Identifier"}
+{: #subject-identifier-example-rfc9493 title="Example Subject Identifier as RFC9493 Subject"}
 
 #### Subject Type {#subject-type}
 Since {{RFC9493}} only concerns itself with the *format* of the identifier and not its *type*, every Subject MUST also include a string-valued `type` field, which identifies the type of Subject.
 
-The following is a non-normative example of a Subject of type `group` with a Subject Identifier in the Email Identifier Format:
+The following is a non-normative example of a Subject of type `group` with a Subject Identifier as a simple string:
+
+~~~ json
+{
+  "type": "group",
+  "id": "engineering@acmecorp.com"
+}
+~~~
+{: #subject-type-group-example title="Example Group Subject Type"}
+
+The following is a non-normative example of a Subject of type `group` with a Subject Identifier in the {{RFC9493}} Email Identifier Format:
 
 ~~~ json
 {
   "type": "group",
   "id": {
     "format" : "email",
-    "email": "alice@acmecorp.com"
+    "email": "engineering@acmecorp.com"
   }
 }
 ~~~
-{: #subject-type-example title="Example Subject Type"}
+{: #subject-type-example-rfc-9493 title="Example Subject Type in RFC9493 Format"}
 
 #### Subject Attributes {#subject-attributes}
-Many authorization systems are stateless, and expect the client (PEP) to pass in any attributes that are expected to be used in the evaluation of the authorization policy. To satisfy this requirement, Subjects MAY include any number of additional attributes as key-value pairs.
+Many authorization systems are stateless, and expect the client (PEP) to pass in any attributes that are expected to be used in the evaluation of the authorization policy. To satisfy this requirement, Subjects MAY include zero or more additional attributes as key-value pairs.
 
 An attribute can be single-valued or multi-valued. It can be a primitive type (string, boolean, number) or a complex type such as a JSON object or JSON array.
 
@@ -157,10 +178,7 @@ The following is a non-normative example of a Subject which adds a string-valued
 ~~~ json
 {
   "type": "user",
-  "id": {
-    "format" : "email",
-    "email": "alice@acmecorp.com"
-  },
+  "id": "alice@acmecorp.com",
   "department": "Sales"
 }
 ~~~
@@ -176,10 +194,7 @@ The following is a non-normative example of a subject which adds the `ip_address
 ~~~ json
 {
   "type": "user",
-  "id": {
-    "format" : "email",
-    "email": "alice@acmecorp.com"
-  },
+  "id": "alice@acmecorp.com",
   "department": "Sales",
   "ip_address": "172.217.22.14"
 }
@@ -195,10 +210,7 @@ The following is a non-normative example of a subject which adds the `device_id`
 ~~~ json
 {
   "type": "user",
-  "id": {
-    "format" : "email",
-    "email": "alice@acmecorp.com"
-  },
+  "id": "alice@acmecorp.com",
   "department": "Sales",
   "ip_address": "172.217.22.14",
   "device_id": "8:65:ee:17:7e:0b"
@@ -213,10 +225,21 @@ A Resource is the target of an access request. It is a JSON ({{RFC8259}}) object
 : REQUIRED. A `string` value that specifies the type of the Resource.
 
 `id`:
-: OPTIONAL. The unique identifier of the Resource, scoped to the `type`, within the scope of the PEP. If specified, the value MUST follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
+: OPTIONAL. The unique identifier of the Resource, scoped to the `type`, within the scope of the PEP. If specified, the value MAY be any valid JSON value, including a simple string. It also MAY follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
 
-#### Example (non-normative)
-The following is a non-normative example of a Resource containing a Subject Identifier in the Opaque Identifier Format:
+#### Examples (non-normative)
+
+The following is a non-normative example of a Resource with a `type` and a simple `id`:
+
+~~~ json
+{
+  "type": "book",
+  "id": "123"
+}
+~~~
+{: #resource-example title="Example Resource"}
+
+The following is a non-normative example of a Resource containing a Subject Identifier in the Opaque Identifier Format, with additional structured attributes:
 
 ~~~ json
 {
@@ -231,7 +254,7 @@ The following is a non-normative example of a Resource containing a Subject Iden
   }
 }
 ~~~
-{: #resource-example title="Example Resource"}
+{: #resource-example-structured title="Example Resource with Subject Identifier and Additional Attributes"}
 
 ### Actions {#actions}
 An Action is the type of access that the requester intends to perform.
@@ -251,7 +274,7 @@ The following is a non-normative example of an action:
 {: #action-example title="Example Action"}
 
 #### Common Action Values
-Since many services follow a Create-Read-Update-Delete convention, a set of common Actions are defined. That said, an Action may be custom, which could be specific to the application being accessed or shared across applications but not listed in the common Actions below.
+Since many services follow a Create-Read-Update-Delete convention, a set of common Actions are defined. That said, an Action may be specific to the application being accessed or shared across applications but not listed in the common Actions below.
 
 The following common Actions are defined:
 
@@ -262,9 +285,6 @@ The following common Actions are defined:
 - `can_delete`: The Action to delete a Resource. The specific entity MAY be identified by the Resource in the request.
 
 PDP Policies MAY incorporate common Action names to provide different decisions based on the Action.
-
-#### Custom Actions
-Any Action that is not one of the above is a custom Action.
 
 ### Context {#context}
 The Context object is a set of attributes that represent environmental or contextual data about the request such as time of day. It is a JSON ({{RFC8259}}) object.
@@ -294,6 +314,7 @@ The Access Evaluation request is a 4-tuple constructed of the four previously de
 : OPTIONAL. The context (or environment) of type Context.
 
 #### Example (non-normative)
+
 ~~~ json
 {
   "subject": {
@@ -371,7 +392,7 @@ A Reason Field is a JSON object that has keys and values of type `string`. The f
 A Reason Object specifies a particular reason. It is a JSON object that has the following fields:
 
 `id`:
-: REQUIRED. A numeric value of that specifies the reason within the scope of a particular response.
+: REQUIRED. A string value that specifies the reason within the scope of a particular response.
 
 `reason_admin`:
 : OPTIONAL. The reason, which MUST NOT be shared with the user, but useful for administrative purposes that indicates why the access was denied. The value of this field is a Reason Field object ({{reason-field}}).
@@ -383,7 +404,7 @@ The following is a non-normative example of a Reason Object:
 
 ~~~ json
 {
-  "id": 0,
+  "id": "0",
   "reason_admin": {
     "en": "Request failed policy C076E82F"
   },
@@ -396,11 +417,12 @@ The following is a non-normative example of a Reason Object:
 {: #example-reason-object title="Example of a Reason Object"}
 
 #### Sample Response with additional context (non-normative)
+
 ~~~ json
 {
   "decision": true,
   "context": {
-    "id": 0,
+    "id": "0",
     "reason_admin": {
       "en": "Request failed policy C076E82F"
     },
@@ -435,17 +457,11 @@ X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
 {
   "subject": {
     "type": "user",
-    "id": {
-      "format": "email",
-      "email": "omri@aserto.com"
-    }
+    "id": "alice@acmecorp.com"
   },
   "resource": {
     "type": "todo",
-    "id": {
-      "format": "opaque",
-      "value: "1"
-    }
+    "id": "1",
   },
   "action": {
     "name": "can_read"
@@ -458,7 +474,7 @@ X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
 {: #example-access-evaluation-request title="Example of an Access HTTPS Evaluation Request"}
 
 ### Access Evaluation HTTPS Response
-The success response to an Access Evaluation Request is an Access Evaluation Response. It is a HTTPS response with `content-type` of `application/json`. Its body is a JSON object that contains the Access Evaluation Response.
+The success response to an Access Evaluation Request is an Access Evaluation Response. It is a HTTPS response with a `status` code of `200`, and `content-type` of `application/json`. Its body is a JSON object that contains the Access Evaluation Response.
 
 Following is a non-normative example of an Access Evaluation HTTPS Response:
 

--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -3,7 +3,7 @@ stand_alone: true
 ipr: none
 cat: std # Check
 submissiontype: IETF
-wg: OpenID TBD
+wg: OpenID AuthZEN
 
 docname: authorization-api-1_0
 
@@ -15,6 +15,7 @@ kw:
   - Access Management
   - XACML
   - OPA
+  - Topaz
   - Cedar
   - PDP
   - PEP
@@ -48,11 +49,10 @@ contributor: # Same structure as author list, but goes into contributors
 
 normative:
   RFC4001: # text representation of IP addresses
-  RFC5234: # REPLACE
-  RFC6749: #OAuth
-  RFC6750: #OAuth 2.0 Bearer Tokens
-  RFC8259: #JSON
+  RFC6749: # OAuth
+  RFC8259: # JSON
   RFC9110: # HTTP Semantics
+  RFC9493: # Subject Identifiers for Security Event Tokens
   XACML:
     title: eXtensible Access Control Markup Language (XACML) Version 1.1
     target: https://www.oasis-open.org/committees/xacml/repository/cs-xacml-specification-1.1.pdf
@@ -67,187 +67,292 @@ normative:
 
 --- abstract
 
-The Authorization API enables Policy Decision Points (PDPs) and Policy Enforcement Points (PEPs) to communicate authorization requests and decisions to each other without requiring knowledge of each other's inner workings. The Authorization API is served by the PDP and is called by the PEP. The Authorization API includes an Evaluations endpoint, which provides specific access decisions and a Search endpoint, which provides generalized access capabilities.
+The Authorization API enables Policy Decision Points (PDPs) and Policy Enforcement Points (PEPs) to communicate authorization requests and decisions to each other without requiring knowledge of each other's inner workings. The Authorization API is served by the PDP and is called by the PEP. The Authorization API includes an Evaluation endpoint, which provides specific access decisions. Other endpoints may be added in the future for other scenarios, including searching for subjects or resources.
 
 --- middle
 
 # Introduction
-
 Computational services often implement access control within their components by separating Policy Decision Points (PDPs) from Policy Enforcement Points (PEPs). PDPs and PEPs are defined in XACML ({{XACML}}) and NIST's ABAC SP 800-162. Communication between PDPs and PEPs follows similar patterns across different software and services that require or provide authorization information. The Authorization API described in this document enables different providers to offer PDP and PEP capabilities without having to bind themselves to one particular implementation of a PDP or PEP.
 
 ## Model
-The Authorization API is a transport-agnostic API published by the PDP, to which the PEP acts as a client. The Transport section of this specification will detail possible bindings e.g. REST. 
+The Authorization API is a transport-agnostic API published by the PDP, to which the PEP acts as a client. The Transport section of this specification details possible bindings, such as HTTPS or gRPC.
 
-Authorization for the Authorization API itself is out of scope for this document, since authorization for REST APIs is well-documented elsewhere. For example, the Authorization API MAY support authorization using an `Authorization` header, using a `basic` or `bearer` token. Support for OAuth 2.0 ({{RFC6749}}) is RECOMMENDED. 
+Authorization for the Authorization API itself is out of scope for this document, since authorization for APIs is well-documented elsewhere. For example, the Authorization API's HTTPS binding MAY support authorization using an `Authorization` header, using a `basic` or `bearer` token. Support for OAuth 2.0 ({{RFC6749}}) is RECOMMENDED. 
 
 ## Features
-The Authorization API has two main features:
+The core feature of the Authorization API is the Access Evaluation API, which enables a PEP to find out if a specific request can be permitted to access a specific resource. The following are non-normative examples:
 
-* An Access Evaluation API, which enables a PEP to find out if a specific request can be permitted to access specific resources. The following are non-normative examples:
-  * Can Alice view document #123?
-  * Can a manager print?
-* A Search API, which enables a PEP to ask open-ended questions. This feature is sometimes referred to as partial evaluation, reverse querying, or contextual access queries by other frameworks. The following are non-normative examples:
-  * What can happen?
-  * What can Alice do?
-  * Who can access record #123?
-  * Who can edit medical records between 8 am and 3 pm?
-  * Who can edit?
-  * What can happen at 3 pm from Glasgow?
-
-# API Specification
-The Authorization API has two parts, Access Evaluation and Search. Each of these is defined below. The definition is transport-agnostic. Refer to the Transport section for example bindings.
+- Can Alice view document #123?
+- Can Alice view document #123 at 16:30 on Tuesday, June 11, 2024?
+- Can a manager print?
 
 ## API Version
 This document describes the API version 1. Any updates to this API through subsequent revisions of this document or other documents MAY augment this API, but MUST NOT modify the API described here. Augmentation MAY include additional API methods or additional parameters to existing API methods, additional authorization mechanisms, or additional optional headers in API requests. All API methods for version 1 MUST be immediately preceded by the relative URL path `/v1/`.
 
 ## Information Model
+The information model for requests and responses include the following entities: Subject, Action, Resource, Context, and Decision. These are all defined below.
 
 ### Subjects {#subjects}
-A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked, or the Subject may be of interest in a Search API call.
+A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.
 
-A Subject is a JSON ({{RFC8259}}) object that contains any number of key-value pair attributes e.g. 
-~~~json
-"username" : "Alice",
-"department": "Sales"
-~~~
+A Subject is a JSON ({{RFC8259}}) object that contains any number of key-value pair attributes. However, there are a minimal number of fields that are required in order to properly resolve a Subject.
 
-An attribute can be single-valued or multi-valued. It can be a primitive type (string, boolean...) or a complex type such as a JSON object.
+`type`:
+: REQUIRED. A `string` value that specifies the type of the Subject.
 
-#### Sample Fields
+`id`:
+: REQUIRED. The unique identifier of the Subject, scoped to the `type`, within the scope of the PEP. If specified, the value MUST follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
 
-Here are sample fields:
+A Subject MUST minimally contain a `type` and an `id`, and MAY contain any number of additional fields.
 
-id:
-: OPTIONAL. A field, whose value is of type `string`, which uniquely identifies the user within the scope of a PEP. This identifier could be an email address, or it might be an internal identifier such as a UUID or employee ID.
-
-ipAddress:
-: OPTIONAL. A field, whose value is of type `string`, which is a {{RFC4001}} text representation of the IP Address
-
-deviceId:
-: OPTIONAL. A field, whose value is of type `string`, which uniquely identifies the device of the Subject
-
-#### Example (non-normative)
-
-The following non-normative example describes a Subject:
+The following is a non-normative example of a subject:
 
 ~~~ json
 {
-  "id": "atul@sgnl.ai",
-  "ipAddress": "172.217.22.14",
-  "deviceId": "8:65:ee:17:7e:0b"
+  "type": "user",
+  "id": {
+    "format" : "email",
+    "email": "alice@acmecorp.com"
+  }
 }
 ~~~
-{: #subjectexample title="Example Subject Object"}
+{: #subject-example title="Example Subject"}
+
+#### Subject Identifier {#subject-identifier}
+The `id` field of a Subject MUST follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}. A Subject MUST include at least one identifier, but MAY include more than one identifier if the format of the field is of type `aliases`.
+
+The following is a non-normative example of a Subject Identifier in the Email Identifier Format:
+
+~~~ json
+{
+  "format" : "email",
+  "email": "alice@acmecorp.com"
+}
+~~~
+{: #subject-identifier-example title="Example Subject Identifier"}
+
+#### Subject Type {#subject-type}
+Since {{RFC9493}} only concerns itself with the *format* of the identifier and not its *type*, every Subject MUST also include a string-valued `type` field, which identifies the type of Subject.
+
+The following is a non-normative example of a Subject of type `group` with a Subject Identifier in the Email Identifier Format:
+
+~~~ json
+{
+  "type": "group",
+  "id": {
+    "format" : "email",
+    "email": "alice@acmecorp.com"
+  }
+}
+~~~
+{: #subject-type-example title="Example Subject Type"}
+
+#### Subject Attributes {#subject-attributes}
+Many authorization systems are stateless, and expect the client (PEP) to pass in any attributes that are expected to be used in the evaluation of the authorization policy. To satisfy this requirement, Subjects MAY include any number of additional attributes as key-value pairs.
+
+An attribute can be single-valued or multi-valued. It can be a primitive type (string, boolean, number) or a complex type such as a JSON object or JSON array.
+
+The following is a non-normative example of a Subject which adds a string-valued `department` attribute:
+
+~~~ json
+{
+  "type": "user",
+  "id": {
+    "format" : "email",
+    "email": "alice@acmecorp.com"
+  },
+  "department": "Sales"
+}
+~~~
+{: #subject-department-example title="Example Subject with Additional Attribute"}
+
+To increase interoperability, a few common attributes are specified below:
+
+##### IP Address {#subject-ip-address}
+The IP Address of the Subject, identified by an `ip_address` field, whose value is a textual representation of an IP Address, as defined in `Textual Conventions for Internet Network Addresses` {{RFC4001}}.
+
+The following is a non-normative example of a subject which adds the `ip_address` attribute:
+
+~~~ json
+{
+  "type": "user",
+  "id": {
+    "format" : "email",
+    "email": "alice@acmecorp.com"
+  },
+  "department": "Sales",
+  "ip_address": "172.217.22.14"
+}
+~~~
+{: #subject-ip-address-example title="Example Subject with IP Address"}
+
+
+##### Device ID {#subject-device-id}
+The Device Identifier of the Subject, identified by a `device_id` field, whose value is a string representation of the device identifier.
+
+The following is a non-normative example of a subject which adds the `device_id` attribute:
+
+~~~ json
+{
+  "type": "user",
+  "id": {
+    "format" : "email",
+    "email": "alice@acmecorp.com"
+  },
+  "department": "Sales",
+  "ip_address": "172.217.22.14",
+  "device_id": "8:65:ee:17:7e:0b"
+}
+~~~
+{: #subject-device-id-example title="Example Subject with Device ID"}
 
 ### Resources {#resources}
-A Resource is the target of an access request. It is a JSON ({{RFC8259}}) object that is constructed just like a Subject object.
+A Resource is the target of an access request. It is a JSON ({{RFC8259}}) object that is constructed similar to a Subject entity.
 
-#### Sample Fields
+`type`:
+: REQUIRED. A `string` value that specifies the type of the Resource.
 
-id:
-: OPTIONAL. The unique identifier of the resource within the scope of the PEP. Its value is a `string` specifying the identifier of the resource. This field MAY be omitted to indicate a class of resources
-
-type:
-: OPTIONAL. The type of the resource. Its value is a `string` that specifies the type of the resource
-
+`id`:
+: OPTIONAL. The unique identifier of the Resource, scoped to the `type`, within the scope of the PEP. If specified, the value MUST follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
 
 #### Example (non-normative)
+The following is a non-normative example of a Resource containing a Subject Identifier in the Opaque Identifier Format:
 
-The following is a non-normative example of a Resource:
-
-~~~json
+~~~ json
 {
-  "id": "123",
   "type": "book",
-  "libraryRecord":{
-    "title": "ABAC's new hit",
+  "id": {
+    "format": "opaque",
+    "value": "123"
+  },
+  "library_record":{
+    "title": "AuthZEN in Action",
     "isbn": "978-0593383322"
   }
 }
 ~~~
-{: #resourceexample title="Example Resource"}
+{: #resource-example title="Example Resource"}
 
 ### Actions {#actions}
-An action is the type of access that the requester intends to perform. There are common actions defined herein, or the action may be custom, which could be specific to the application being accessed or shared across applications but not listed in the common actions below. Action is a JSON ({{RFC8259}}) object that is constructed just like a Subject or Resource object.
+An Action is the type of access that the requester intends to perform.
 
-#### Common Action Values (non-normative)
-The following common actions are defined herein:
-*  **access**: A generic action that could mean any type of access. This is useful if the policy or application is not interested in different decisions for different types of actions
-* **create**: The action to create a new entity, which MAY be defined by the `resource` field in the request
-* **read**: The action to read the content. Based on the resource being accessed, this could mean a list functionality or reading an individual resource's contents
-* **update**: The action to update the content of an existing entity. This MAY represent a partial update or an entire replacement of the entity. The entity MAY be identified by the resource in the request
-* **delete**: The action to delete an entity. The entity MAY be identified by the resource in the request
+Action is a JSON ({{RFC8259}}) object that contains at least a `name` field.
 
-Policies MAY incorporate common action names to provide different decisions based on the action
+`name`:
+: REQUIRED. The name of the Action.
+
+The following is a non-normative example of an action:
+
+~~~ json
+{
+  "name": "can_read"
+}
+~~~
+{: #action-example title="Example Action"}
+
+#### Common Action Values
+Since many services follow a Create-Read-Update-Delete convention, a set of common Actions are defined. That said, an Action may be custom, which could be specific to the application being accessed or shared across applications but not listed in the common Actions below.
+
+The following common Actions are defined:
+
+- `can_access`: A generic Action that could mean any type of access. This is useful if the policy or application is not interested in different decisions for different types of Actions.
+- `can_create`: The Action to create a new entity, which MAY be defined by the `resource` field in the request.
+- `can_read`: The Action to read the content. Based on the Resource being accessed, this could mean a list functionality or reading an individual Resource's contents.
+- `can_update`: The Action to update the content of an existing Resource. This represents a partial update or an entire replacement of an entity that MAY be identified by the Resource in the request.
+- `can_delete`: The Action to delete a Resource. The specific entity MAY be identified by the Resource in the request.
+
+PDP Policies MAY incorporate common Action names to provide different decisions based on the Action.
 
 #### Custom Actions
-Any action that is not one of the above is custom. Policies MAY incorporate custom action names if decisions need to be taken differently for different custom actions
+Any Action that is not one of the above is a custom Action.
 
 ### Context {#context}
-The Context object is a set of attributes that represent environmental or contextual data about the request such as time of day. It is a JSON ({{RFC8259}}) object that is constructed just like a Subject, Resource, or Action object.
+The Context object is a set of attributes that represent environmental or contextual data about the request such as time of day. It is a JSON ({{RFC8259}}) object.
+
+The following is a non-normative example of a Context:
+
+~~~ json
+{
+  "time": "1985-10-26T01:22-07:00"
+}
+~~~
+{: #context-example title="Example Context"}
 
 ### The Access Evaluation API Request
+The Access Evaluation request is a 4-tuple constructed of the four previously defined entities:
 
-The request follows a format similar to that used in XACML-JSON (TBD add normative reference) or AWS Cedar i.e. a collection of _attributes_ grouped together in categories that reflect the grammatical purpose or function of said attribute. This specification defines 4 such categories as aforementioned:
+`subject`:
+: REQUIRED. The subject (or principal) of type Subject
 
-* The subject (or principal) of type Subject
-* The action (or verb) of type Action
-* The resource of type Resource
-* The context (or environment) of type Context
+`action`:
+: REQUIRED. The action (or verb) of type Action.
+
+`resource`:
+: REQUIRED. The resource of type Resource.
+
+`context`:
+: OPTIONAL. The context (or environment) of type Context.
 
 #### Example (non-normative)
-
-~~~json
+~~~ json
 {
-  "subject":{
+  "subject": {
+    "type": "user",
     "id": {
-      "username": "Art",
-      "jwt": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0MiIsIm5hbWUiOiJBcnQgVmFuZGVsYXkiLCJpYXQiOjE1MTYyMzkwMjJ9.QR3kS983lnaRVM1ZVJ_TM7XxJDPppELnCSCV_upUHQIGs28mB4JE_VqC9WBlcCYIYZn_E3r1RXarnFBe5UAy9g"
+      "format": "iss_sub",
+      "iss": "https://issuer.example.com/",
+      "sub": "145234573"
     }
   },
-  "resource":{
+  "resource": {
+    "type": "path",
     "path": "/api/account/123"
   },
-  "action":{
+  "action": {
+    "name": "can_read",
     "method": "GET"
   },
-  "context":{
+  "context": {
     "time": "1985-10-26T01:22-07:00"
   }
 }
 ~~~
+{: #request-example title="Example Request"}
 
 ### The Access Evaluation API Response
+The simplest form of a response is simply a boolean representing a Decision, indicated by a `"decision"` field. 
 
-The simplest form of a response is simply a boolean representing a decision, indicated by a `"decision"` field. In this specification, assuming the evaluation was successful, there are only 2 possible responses:
+`decision`:
+: REQUIRED. A boolean value that specifies whether the Decision is to allow or deny the operation.
 
-* `true`: The access request is permitted to go forward
-* `false`: The access request is denied and MUST NOT be permitted to go forward
+In this specification, assuming the evaluation was successful, there are only 2 possible responses:
+- `true`: The access request is permitted to go forward.
+- `false`: The access request is denied and MUST NOT be permitted to go forward.
 
-#### Query Decision {#query-decision}
+The response object MUST contain this boolean-valued Decision key.
 
-The following is a non-normative example of a simple query decision:
+#### Access Evaluation Decision {#decision}
+The following is a non-normative example of a simple Decision:
 
 ~~~ json
 {
   "decision": true
 }
 ~~~
+{: #decision-example title="Example Decision"}
 
-#### Additional context in a response
-
+#### Additional Context in a Response
 In addition to a `"decision"`, a response may contain a `"context"` field which can be any JSON object.  This context can convey additional information that can be used by the PEP as part of the decision evaluation process. Examples include:
 
-* XACML's notion of "advice" and "obligations"
-* Hints for rendering UI state
-* Instructions for step-up authentication
+- XACML's notion of "advice" and "obligations"
+- Hints for rendering UI state
+- Instructions for step-up authentication
 
-#### Example context
-
+#### Example Context
 An implementation MAY follow a structured approach to `"context"`, in which it presents the reasons that an authorization request failed.
 
-* A list of identifiers representing the items (policies, graph nodes, tuples) that were used in the decision-making process
-* A list of reasons as to why access is permitted or denied.
+- A list of identifiers representing the items (policies, graph nodes, tuples) that were used in the decision-making process.
+- A list of reasons as to why access is permitted or denied.
 
 ##### Reasons
 Reasons MAY be provided by the PDP. 
@@ -260,22 +365,23 @@ A Reason Field is a JSON object that has keys and values of type `string`. The f
   "en": "location restriction violation"
 }
 ~~~
+{: #reason-example title="Example Reason"}
 
 ###### Reason Object {#reason-object}
 A Reason Object specifies a particular reason. It is a JSON object that has the following fields:
 
-id:
-: REQUIRED. A numeric value of that specifies the reason within the scope of a particular response
+`id`:
+: REQUIRED. A numeric value of that specifies the reason within the scope of a particular response.
 
-reason_admin:
+`reason_admin`:
 : OPTIONAL. The reason, which MUST NOT be shared with the user, but useful for administrative purposes that indicates why the access was denied. The value of this field is a Reason Field object ({{reason-field}}).
 
-reason_user:
-: OPTIONAL. The reason, which MAY be shared with the user that indicates why the access was denied. The value of this field is a Reason Field object ({{reason-field}})
+`reason_user`:
+: OPTIONAL. The reason, which MAY be shared with the user that indicates why the access was denied. The value of this field is a Reason Field object ({{reason-field}}).
 
 The following is a non-normative example of a Reason Object:
 
-~~~json
+~~~ json
 {
   "id": 0,
   "reason_admin": {
@@ -290,8 +396,7 @@ The following is a non-normative example of a Reason Object:
 {: #example-reason-object title="Example of a Reason Object"}
 
 #### Sample Response with additional context (non-normative)
-
-~~~json
+~~~ json
 {
   "decision": true,
   "context": {
@@ -306,123 +411,20 @@ The following is a non-normative example of a Reason Object:
   }
 }
 ~~~
+{: #response-with-context-example title="Example Response with Context"}
 
-## Resource Query {#resource-query}
-An Resource Query is a question about whether a subject can access a specific resource. It is a JSON object with the following fields:
+# Transport
 
-action:
-: REQUIRED. The type of access that is to be performed. Its value is a `string` that describes the action. This value of this field is as described in the Actions section ({{actions}}).
+This specification defines an HTTPS binding which MUST be implemented by a compliant PDP.
 
-resource:
-: REQUIRED. The resource to which this query relates. Its format is as described in the Resources section ({{resources}})
+Additional transport bindings (e.g. gRPC) MAY be defined in the future in the form of profiles, and MAY be implemented by a PDP.
 
-The following is a non-normative example of an Resource Query:
+## HTTPS Binding
 
-~~~ json
-{
-  "action": "stream",
-  "resource": {
-    "id": "1234",
-    "type": "webcam",
-    "attributeNames": [
-      "lowRes",
-      "motionOnly"
-    ]
-  }
-}
-~~~
-{: #example-resource-query title="Example Resource Query"}
+### Access Evaluation HTTPS Request
+The Access Evaluation Request is a HTTPS request with `content-type` of `application/json`. Its body is a JSON object that contains the Access Evaluation Request, as defined above.
 
-### Resource Query Decision {#resource-query-decision}
-An Resource Query Decision is a tuple of an resource, action and a decision, represented as a JSON object. It has the following fields:
-
-action:
-: OPTIONAL. The action for which the decision is provided. The format is as described in the Actions section ({{actions}})
-
-resource:
-: OPTIONAL. The resource for which the decision is provided. The format is as described in the Resources section ({{resources}}). This resource MAY be greater in scope than described in the Resource Query ({{resource-query}}), i.e. It MAY describe an resource more generally than specified in the Resource Query. However, it MUST NOT be more specific than the resource described in the Resource Query.
-
-decision:
-: REQUIRED. The decision for the above `resource` and `action`. The format is as described in the Query Decision section ({{query-decision}})
-
-reason_ids:
-: OPTIONAL. An array of reason identifiers that indicate specific resons why the resource query was denied
-
-The following is a non-normative example of an Resource Query Decision:
-
-~~~ json
-{
-  "action": "stream",
-  "resource": {
-    "id": "1234"
-  },
-  "decision": "deny",
-  "reason_ids": [0,2,3]
-}
-~~~
-{: #example-resource-query-decision title="Example Resource Query Decision"}
-
-## Collections {#collections}
-An API request or response MAY contain a collection of items, such as an array of strings representing various attribute names, or an array of Resource Query Decision objects ({{resource-query-decision}}). The objects in a collection MAY overlap in scope. For example:
-
-~~~ json
-[
-  {
-    "resource": {
-      "id": "1234",
-      "attributeNames": [
-        "homeAddress",
-        "title"
-      ]
-    },
-    "decision": "deny",
-    "reason_ids": [1]
-  },
-  {
-    "resource": {
-      "id": "1234"
-    },
-    "decision": "allow"
-  }
-]
-~~~
-{: #collection-example title="Example Overlapping Collection"}
-
-The receiver of a collection MUST interpret the collection in a way that results in the least-privilege access. In the above example, this means that the subject has access to the resource identified by "1234", but not to the "homeAddress" and "title" attributes of that resource.
-
-## Error Responses
-The following error responses are common to all methods of the Authorization API. The error response is indicated by an HTTP status code ({{Section 15 of RFC9110}}) that indicates error.
-
-The following errors are indicated by the status codes defined below:
-
-| Code | Description  | HTTP Body Content |
-|------|--------------|-------------------|
-| 400  | Bad Request  | An error message string |
-| 401  | Unauthorized | An error message string |
-| 403  | Forbidden    | An error message string |
-| 500  | Internal error | An error message string |
-{: #table-error-status-codes title="Error status codes"}
-
-## Access Evaluations API
-The Access Evaluations API is a means for a PEP to request decisions for a number of resources for a single request context.
-
-The Access Evaluations API is available at the relative URL `/evaluations/` via the `POST` HTTP method.
-
-### Access Evaluation Request
-
-subject:
-: REQUIRED. A subject as described in the Subjects section ({{subjects}})
-
-action:
-: REQUIRED. An action as described in the Actions section ({{actions}})
-
-resource:
-: OPTIONAL. A resource as described in the Resources section ({{resources}})
-
-context:
-: OPTIONAL. The environment/context attributes, as described in the Context section ({{context}})
-
-The following is a non-normative example of an Access Evaluation Request:
+The following is a non-normative example of a the HTTPS binding of the Access Evaluation Request:
 
 ~~~ http
 POST /access/v1/evaluation HTTP/1.1
@@ -432,40 +434,33 @@ X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
 
 {
   "subject": {
-    "id": "omri@aserto.com",
-  },
-  "action": {
-    "action": "can_read"
+    "type": "user",
+    "id": {
+      "format": "email",
+      "email": "omri@aserto.com"
+    }
   },
   "resource": {
     "type": "todo",
-    "id": "1"
+    "id": {
+      "format": "opaque",
+      "value: "1"
+    }
+  },
+  "action": {
+    "name": "can_read"
   },
   "context": {
+    "time": "1985-10-26T01:22-07:00"
   }
 }
 ~~~
-{: #example-access-evaluation-request title="Example of an Access Evaluation Request"}
+{: #example-access-evaluation-request title="Example of an Access HTTPS Evaluation Request"}
 
-### Access Evaluation Response
-The success response to an Access Evaluation Request is an Access Evaluation Response. It is a HTTP response of type `application/json`. Its body is a JSON object that contains the following fields:
+### Access Evaluation HTTPS Response
+The success response to an Access Evaluation Request is an Access Evaluation Response. It is a HTTPS response with `content-type` of `application/json`. Its body is a JSON object that contains the Access Evaluation Response.
 
-decision:
-: REQUIRED. A boolean value (`true` or `false`) as described in the Resource Query Decision section ({{resource-query-decision}}).
-
-iat:
-: OPTIONAL. The issued at time in `integer` format, expressed as epoch milliseconds
-
-exp:
-: OPTIONAL. The time in `integer` format, expressed at epoch milliseconds, after which the response SHOULD NOT be used
-
-context:
-: OPTIONAL. A JSON object that provides additional evaluation context.
-
-evaluationDuration:
-: OPTIONAL. The time in milliseconds, in `integer` format, that it took to respond to the Access Evaluation Request.
-
-Following is a non-normative example of an Access Evaluation Response:
+Following is a non-normative example of an Access Evaluation HTTPS Response:
 
 ~~~ http
 HTTP/1.1 OK
@@ -476,449 +471,74 @@ X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
   "decision": true
 }
 ~~~
-{: #example-access-evaluation-response title="Example of an Access Evaluation Response"}
+{: #example-access-evaluation-response title="Example of an Access HTTPS Evaluation Response"}
 
-### Access Evaluations Request
+### Error Responses
+The following error responses are common to all methods of the Authorization API. The error response is indicated by an HTTPS status code ({{Section 15 of RFC9110}}) that indicates error.
 
-This API is used for boxcarring more than one request to a PDP.
+The following errors are indicated by the status codes defined below:
 
-The content of the request body is a JSON Object with the following fields:
+| Code | Description  | HTTPS Body Content |
+|------|--------------|-------------------|
+| 400  | Bad Request  | An error message string |
+| 401  | Unauthorized | An error message string |
+| 403  | Forbidden    | An error message string |
+| 500  | Internal error | An error message string |
+{: #table-error-status-codes title="HTTPS Error status codes"}
 
-subject:
-: REQUIRED. A subject as described in the Subjects section ({{subjects}})
-
-queries:
-: REQUIRED. An array of queries defined in Resource Query section ({{resource-query}}) about access to specific resources
-
-The following is a non-normative example of an Access Evaluations Request:
-
-~~~ http
-POST /access/v1/evaluations HTTP/1.1
-Host: pdp.mycompany.com
-Authorization: Bearer <myoauthtoken>
-X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
-
-{
-  "subject": {
-    "id": "atul@sgnl.ai",
-  },
-  "queries": [
-    {
-      "action": "read",
-      "resource": {
-        "type": "customer"
-      }
-    },
-    {
-      "action": "read",
-      "resource": {
-        "id": "efgh",
-        "type": "customer",
-        "attributeNames": [
-          "homeAddress"
-        ]
-      }
-    }
-  ]
-}
-~~~
-{: #example-access-evaluations-request title="Example of an Access Evaluations Request"}
-
-### Access Evaluations Response
-The success response to an Access Evaluations Request is an Access Evaluations Response. It is a HTTP response of type `application/json`. Its body is a JSON object that contains the following fields:
-
-iat:
-: OPTIONAL. The issued at time in `integer` format, expressed as epoch milliseconds
-
-exp:
-: OPTIONAL. The time in `integer` format, expressed at epoch milliseconds, after which the response SHOULD NOT be used
-
-subject:
-: OPTIONAL. The subject for which the response is being issued. The format of this field is as described in the Subjects section ({{subjects}})
-
-decisions:
-: REQUIRED. An array of Resource Query Decisions as described in the Resource Query Decision section ({{resource-query-decision}}).
-
-reasons:
-: OPTIONAL. An array of Reason Objects ({{reason-object}}) which provide details of every reason identifier specified in the `decisions` field.  This field is REQUIRED if there is at least one decision in the `decisions` field that specifies a `reason_ids` field. The content of the `reasons` field MUST provide details of every identifier in the `reason_ids` fields in the `decisions` array.
-
-evaluationDuration:
-: OPTIONAL. The time in milliseconds, in `integer` format, that it took to respond to the Access Evaluation Request.
-
-Following is a non-normative example of an Access Evaluations Response:
+### Request Identification
+All requests to the API MAY have request identifiers to uniquely identify them. The API client (PEP) is responsible for generating the request identifier. If present, the request identifier SHALL be provided using the HTTPS Header `X-Request-ID`. The value of this header is an arbitrary string. The following non-normative example describes this header:
 
 ~~~ http
-HTTP/1.1 OK
-Content-type: application/json
-X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
-
-{
-  "iat": 1234567890,
-  "exp": 1234568890,
-  "subject": {
-    "id": "atul@sgnl.ai"
-  }
-  "decisions": [
-    {
-      "action": "read",
-      "resource": {
-        "type": "customer"
-      },
-      "decision": "deny",
-      "reasons": [1]
-    },
-    {
-      "action": "read",
-      "resource": {
-        "id": "efgh",
-        "type": "customer",
-      },
-      "decision": "allow"
-    }
-  ],
-  "reasons": [
-    {
-      "id": 0,
-      "reason_admin": {
-        "en": "Request failed policy C076E82F"
-      },
-      "reason_user": {
-        "en-403": "Insufficient privileges. Contact your administrator",
-        "es-403": "Privilegios insuficientes. Póngase en contacto con su administrador"
-      }
-    },
-    {
-      "id": 1,
-      "reason_admin": {
-        "en-410": "Access attempt from multiple regions"
-      },
-      "reason_user": {
-        "en": "Insufficient privileges. Contact your administrator"
-      }
-    }
-  ],
-  "evaluationDuration": 30
-}
-~~~
-{: #example-access-evaluations-response title="Example of an Access Evaluation Response"}
-
-## Resource Search API
-The Resource Access Search API enables a PEP to find out all resources a subject has access to.
-
-The Resource Access Search API is available at the relative URL `/resourcesearch/` via the `POST` HTTP method
-
-### Resource Search Request
-A Resource Search Request has request parameters and a request body. The request parameters are:
-
-pageToken:
-: OPTIONAL. A string value that is returned in a previous Search Response ({{search-response}}), which indicates that the request is a continuation of a previous request
-
-pageSize:
-: OPTIONAL. The maximum number of `decision` items in a Search Response ({{search-response}}). The API MAY return a smaller number of items but SHOULD NOT return a number of items that is greater than this value
-
-The content of a Search Request body is a JSON object with the following fields:
-
-subject:
-: REQUIRED. A subject as described in the Subjects section ({{subjects}})
-
-queries:
-: REQUIRED. An array of `string` values as described in the Actions section ({{actions}}).
-
-The following is a non-normative example of a Search Request:
-
-~~~ http
-POST /resourcesearch?pageToken=NWU0OGFiZTItNjI1My00NTQ5LWEzYTctNWQ1YmE1MmVmM2Q4&pageSize=2 HTTP/1.1
-Host: pdp.mycompany.com
-Authorization: Bearer <myoauthtoken>
-
-{
-  "subject": {
-    "id": "atul@sgnl.ai"
-    "ipAddress": "172.217.22.14",
-  }
-  "queries": ["delete", "read"],
-}
-~~~
-{: #example-search-request title="Example Access Request"}
-
-### Resource Query result {#resource-query-result}
-A Resource Query Result is a JSON object representing a single result for a Resource Search Request. The Resource Query result always convey a positive ("Allow") decision.
-Its body is a JSON object with teh following fields:
-
-action:
-: REQUIRED. The action that the subject is granted on this resource.
-
-resource:
-: REQUIRED. An object representing the resource.
-
-The following is a non-normative example of a Resource Query Result:
-
-~~~ json
-{
-  "action": "stream",
-  "resource": {
-    "id": "1234"
-  }
-}
-~~~
-{: #example-resource-query-result title="Example Resource Query Result"}
-
-### Resource Search Response {#search-response}
-The success response to a Resource Search Request is a Resource Search Response. It is a HTTP response of type `application/json`. The Resource Search Response contains only positive results: only those Resources that the given Subject has access to. Any Resources not returned are therefore not accessible by the subject.
-Its body is a JSON object that contains the following fields:
-
-iat:
-: REQUIRED. The issued at time in `integer` format, expressed as epoch milliseconds
-
-exp:
-: REQUIRED. The time in `integer` format, expressed at epoch milliseconds, after which the response SHOULD NOT be used
-
-subject:
-: REQUIRED. The subject for which the response is being issued. The format of this field is as described in the Subjects section ({{subjects}})
-
-decisions:
-: REQUIRED. An array of Resource Query Results as described in the Resource Query Result section ({{resource-query-result}}).
-
-nextPageToken:
-: OPTIONAL. A string that MAY be used in a Search Request to fetch the next set of responses.
-
-Following is a non-normative example of a Resource Search Response:
-
-~~~ http
-HTTP/1.1 OK
-Content-type: application/json
-X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305720
-
-{
-  "iat": 1234567890,
-  "exp": 1234568890,
-  "subject": {
-    "id": "atul@sgnl.ai"
-    "ipAddress": "172.217.22.14",
-  }
-  "decisions": [
-    {
-      "action": "read",
-      "resource": {
-        "id": "efgh",
-        "type": "customer",
-      }
-    },
-    {
-      "action": "delete",
-      "resource": {
-        "id": "report.docx",
-        "type": "Document",
-      }
-    }
-  ],
-  "nextPageToken": "1DlR0Em5panAPy5llasLPfNUpDztEKgTDKF2I5gPwymnc"
-}
-~~~
-{: #example-resource-search-response title="Example of a Resource Search Response"}
-
-## Subject Search API
-The Access Subject Search API does the reverse of the Search API: it enables a PEP or client to find out all the subjects that can access a given resource.
-
-The Access Subject Search API is available at the relative URL `/subjectsearch/` via the `POST` HTTP method
-
-### Subject Search Request
-A Subject Search Request has request parameters and a request body. The request parameters are:
-
-pageToken:
-: OPTIONAL. A string value that is returned in a previous Subject Search Response ({{subject-search-response}}), which indicates that the request is a continuation of a previous request
-
-pageSize:
-: OPTIONAL. The maximum number of `decision` items in a Subject Search Response ({{subject-search-response}}). The API MAY return a smaller number of items but SHOULD NOT return a number of items that is greater than this value
-
-The content of a Subject Search Request body is a JSON object with the following fields:
-
-resource:
-: REQUIRED. A resource as described in the Resources section ({{resources}})
-
-queries:
-: REQUIRED. An array of `string` values as described in the Actions section ({{actions}}).
-
-The following is a non-normative example of a Subject Search Request:
-
-~~~ http
-POST /subjectsearch?pageToken=NWU0OGFiZTItNjI1My00NTQ5LWEzYTctNWQ1YmE1MmVmM2Q4&pageSize=2 HTTP/1.1
-Host: pdp.mycompany.com
-Authorization: Bearer <myoauthtoken>
-
-{
-  "resource": {
-    "id": "somevalue",
-    "type": "document",
-    "attributeNames": [
-      "author",
-      "createDate",
-      "lastUpdated"
-    ]
-   },
-  "queries": ["delete", "read", "write"]
-}
-~~~
-{: #example-subject-search-request title="Example Subject Search Request"}
-
-### Subject Search Response {#subject-search-response}
-The success response to a Subject Search Request is a Subject Search Response. It is a HTTP response of type `application/json`. Its body is a JSON object that contains the following fields:
-
-iat:
-: REQUIRED. The issued at time in `integer` format, expressed as epoch milliseconds
-
-subject:
-: REQUIRED. The subject for which the response is being issued. The format of this field is as described in the Subjects section ({{subjects}})
-
-decisions:
-: REQUIRED. An array of Subject Query results as described below ({{subject-query-result}}).
-
-nextPageToken:
-: OPTIONAL. A string that MAY be used in a Search Request to fetch the next set of responses.
-
-#### Subject Query Result {#subject-query-result}
-A Subject Query Result is array of Subject Query Decisions ({{example-subject-query-decision}}). It is JSON object combining a subject, a list of resource attribute names and an action. Given that a Subject Query result is expected to be the response to a Subject Search, only positive matches should be returned; i.e., only those subjects that match the search criteria (those subjects that are allowed to access the provided Resource Attributes). Any Subjects absent from the results do not have any access to the Resource. 
-A Subject Query Result has the following fields:
-
-actions:
-: OPTIONAL. An Array of the action for which the decision is provided. The format is as described in the Actions section ({{actions}}). The values in this list should match the values provided as queries in the Subject Search request.
-
-attributeNames:
-: OPTIONAL. An Array of attribute names of the resource for which the response applies. The attribute is provided only if attributes were part of the Subject search request. In that case, the attribute names must match those that are part of the request.
-
-subject:
-: REQUIRED. The subject for which the decision is provided. The format is as described in the Subjects section ({{subjects}}). 
-
-The following is a non-normative example of a Subject Query Decision:
-
-~~~ json
-{
-  "actions": ["delete", "read", "write"],
-  "attributeNames": [
-    "author",
-    "createDate",
-    "lastUpdated"
-  ],
-  "subject": {
-    "id": "alex@3edges.com"
-  }
-}
-~~~
-{: #example-subject-query-decision title="Example Subject Query Decision"}
-
-Following is a non-normative example of a Subject Search Response:
-
-~~~ http
-HTTP/1.1 OK
-Content-type: application/json
-X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305720
-
-{
-  "iat": 1234567890,
-  "resource": {
-    "id": "somevalue",
-    "type": "document",
-    "attributeNames": [
-      "author",
-      "createDate",
-      "lastUpdated"
-    ]
-  },
-  "queries": [
-    "write",
-    "read"
-  ],
-  "decisions": [
-    {
-      "action": "write",
-      "attributeNames": [
-        "author"
-      ],
-      "subject": {
-        "id": "alex@3edges.com"
-      }
-    },
-    {
-      "action": "read",
-      "attributeNames": [
-        "author",
-        "createDate",
-        "lastUpdated"
-      ],
-      "subject": {
-        "id": "alex@3edges.com"
-      }
-    },
-    {
-      "action": "read",
-      "attributeNames": [
-        "author",
-        "createDate",
-        "lastUpdated"
-      ],
-      "subject": {
-        "id": "Janet@3edges.com"
-      }
-    }
-  ],
-  "nextPageToken": "1DlR0Em5panAPy5llasLPfNUpDztEKgTDKF2I5gPwymnc"
-}
-~~~
-{: #example-subject-search-response title="Example of a Subject Search Response"}
-
-# Transport
-
-## REST Binding
-
-## Request Identification
-All requests to the API MAY have request identifiers to uniquely identify them. The API client (PEP) is responsible for generating the request identifier. If present, the request identifier SHALL be provided using the HTTP Header `X-Request-ID`. The value of this header is an arbitrary string. The following non-normative example describes this header:
-
-~~~ http
-POST /access/v1/evaluations HTTP/1.1
+POST /access/v1/evaluation HTTP/1.1
 Authorization: Bearer mF_9.B5f-4.1JqM
 X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
 ~~~
-{: #requestidexample title="Request Id Example"}
+{: #request-id-example title="Example HTTPS request with a Request Id Header"}
 
-## Request Identification in a Response
-A PDP responding to an Authorization API request MUST include a request identifier in the response. The request identifier is specified in the HTTP Response header: `X-Request-ID`. If the PEP specified a request identifier in the request, the PDP MUST include the same identifier in the response to that request. If the PEP has not specified a request identifier in the request, the PDP MUST generate a new request identifier in its response to the PEP. The following is an non-normative example of an HTTP Response with this header:
+### Request Identification in a Response
+A PDP responding to an Authorization API request that contains an `X-Request-ID` header MUST include a request identifier in the response. The request identifier is specified in the HTTPS Response header: `X-Request-ID`. If the PEP specified a request identifier in the request, the PDP MUST include the same identifier in the response to that request.
+
+The following is a non-normative example of an HTTPS Response with this header:
 
 ~~~ http
 HTTP/1.1 OK
 Content-type: application/json
 X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
 ~~~
-{: #example-response-request-id title="Example HTTP response with a Request Id"}
+{: #example-response-request-id title="Example HTTPS response with a Request Id Header"}
 
 # IANA Considerations {#IANA}
 
 TBS
 
-
 # Security Considerations {#Security}
 
 TBS
 
-
 --- back
 
 # Terminology
-
 Subject:
-: The user or robotic principal about whom the Authorization API call is being made
+: The user or robotic principal about whom the Authorization API call is being made.
 
 Resource:
-: The target of the request; the resource about which the Authorization API is being made
+: The target of the request; the resource about which the Authorization API is being made.
 
 Action:
-: The operation the Subject has attempted on the Resource in an Authorization API call
+: The operation the Subject has attempted on the Resource in an Authorization API call.
+
+Context:
+: The environmental or contextual attributes for this request.
+
+Decision:
+: The value of the evaluation decision made by the PDP: `true` for "allow", `false` for "deny".
 
 PDP:
-: Policy Decision Point. The component or system that provides authorization decisions over the network interface defined here as the Authorization API
+: Policy Decision Point. The component or system that provides authorization decisions over the network interface defined here as the Authorization API.
 
 PEP:
-: Policy Enforcement Point. The component or system that requests decisions from the PDP and enforces access to specific requests based on the decisions obtained from the PDP
-
+: Policy Enforcement Point. The component or system that requests decisions from the PDP and enforces access to specific requests based on the decisions obtained from the PDP.
 
 # Acknowledgements {#Acknowledgements}
 {: numbered="false"}


### PR DESCRIPTION
* removed Evaluations and Search APIs
* cleaned up all JSON
* added subject IDs as per RFC9493 (subsuming @tulshi's earlier PR)
* added required `type` field for subjects and objects as discussed
* added required `name` field for actions as discussed
* cleanly factored HTTPS binding into the transports section
* added example annotations for every JSON example
* fixed all the bullets that weren't rendering correctly
* grammar and typos
