### PR TITLE
make resource id mandatory

### DIFF
--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -225,7 +225,7 @@ A Resource is the target of an access request. It is a JSON ({{RFC8259}}) object
 : REQUIRED. A `string` value that specifies the type of the Resource.
 
 `id`:
-: OPTIONAL. The unique identifier of the Resource, scoped to the `type`. If specified, the value MAY be any valid JSON value, including a simple string. It also MAY follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
+: REQUIRED. The unique identifier of the Resource, scoped to the `type`. The value MAY be any valid JSON value, including a simple string. It also MAY follow the format specified by the `Subject Identifiers for Security Event Tokens` specification {{RFC9493}}.
 
 #### Examples (non-normative)
 

--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -326,8 +326,8 @@ The Access Evaluation request is a 4-tuple constructed of the four previously de
     }
   },
   "resource": {
-    "type": "path",
-    "path": "/api/account/123"
+    "type": "account",
+    "id": "123"
   },
   "action": {
     "name": "can_read",


### PR DESCRIPTION
This PR captures the AuthZEN discussion from June 25 2024, where the WG decided to make Resource ID mandatory.
