### PR TITLE
clarify https error codes vs deny decisions

### DIFF
--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -502,6 +502,12 @@ The following errors are indicated by the status codes defined below:
 | 500  | Internal error | An error message string |
 {: #table-error-status-codes title="HTTPS Error status codes"}
 
+Note: HTTPS errors are returned by the PDP to indicate an error condition relating to the request or its processing, and are unrelated to the outcome of an authorization decision, which is always returned with a `200` status code and a response payload.
+
+To make this concrete:
+* a `401` HTTPS status code indicates that the caller (policy enforcement point) did not properly authenticate to the PDP - for example, by omitting a required `Authorization` header, or using an invalid access token.
+* the PDP indicates to the caller that the authorization request is denied by sending a response with a `200` HTTPS status code, along with a payload of `{ "decision": false }`.
+
 ### Request Identification
 All requests to the API MAY have request identifiers to uniquely identify them. The API client (PEP) is responsible for generating the request identifier. If present, the request identifier SHALL be provided using the HTTPS Header `X-Request-ID`. The value of this header is an arbitrary string. The following non-normative example describes this header:
 


### PR DESCRIPTION
This addresses issue https://github.com/openid/authzen/issues/86
