### PR TITLE
facelift for table/markdown interop results and generation

### DIFF
--- a/interop/authzen-interop-website/docs/results/3edges.md
+++ b/interop/authzen-interop-website/docs/results/3edges.md
@@ -13,45 +13,959 @@ AUTHZEN_PDP_API_KEY="Basic <api-key-redacted>" yarn test https://api-authzen-aut
 yarn run v1.22.19
 $ node build/test/runner.js https://api-authzen-authz.3edges.io markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/RockSolidKnowledge.md
+++ b/interop/authzen-interop-website/docs/results/RockSolidKnowledge.md
@@ -13,45 +13,959 @@ yarn test https://authzen.identityserver.com markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen.identityserver.com markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/aserto.md
+++ b/interop/authzen-interop-website/docs/results/aserto.md
@@ -15,45 +15,959 @@ yarn test https://authzen-proxy.demo.aserto.com markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen-proxy.demo.aserto.com markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/authzforce.md
+++ b/interop/authzen-interop-website/docs/results/authzforce.md
@@ -13,45 +13,959 @@ yarn test https://restful-pdp-vji43cydea-uc.a.run.app markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://restful-pdp-vji43cydea-uc.a.run.app markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/axiomatics.md
+++ b/interop/authzen-interop-website/docs/results/axiomatics.md
@@ -13,45 +13,959 @@ yarn test https://pdp.alfa.guide markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://pdp.alfa.guide markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/cerbos.md
+++ b/interop/authzen-interop-website/docs/results/cerbos.md
@@ -13,45 +13,959 @@ yarn test https://authzen-proxy-demo.cerbos.dev markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/hexa.md
+++ b/interop/authzen-interop-website/docs/results/hexa.md
@@ -13,45 +13,959 @@ yarn test https://interop.authzen.hexaorchestration.org markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://interop.authzen.hexaorchestration.org markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/kogito.md
+++ b/interop/authzen-interop-website/docs/results/kogito.md
@@ -13,45 +13,959 @@ yarn test https://authzen-proxy-demo.azerad.org markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen-proxy-demo.azerad.org markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/opa.md
+++ b/interop/authzen-interop-website/docs/results/opa.md
@@ -13,45 +13,959 @@ yarn test https://authzen-opa-proxy.demo.aserto.com markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen-opa-proxy.demo.aserto.com markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/permit.md
+++ b/interop/authzen-interop-website/docs/results/permit.md
@@ -13,45 +13,959 @@ yarn test https://permit-authzen-interop.up.railway.app markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://permit-authzen-interop.up.railway.app markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/plainid.md
+++ b/interop/authzen-interop-website/docs/results/plainid.md
@@ -13,45 +13,959 @@ yarn test https://authzeninteropt.se-plainid.com markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzeninteropt.se-plainid.com markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/sgnl.md
+++ b/interop/authzen-interop-website/docs/results/sgnl.md
@@ -13,45 +13,959 @@ AUTHZEN_PDP_API_KEY="Bearer <token_redacted>" yarn test https://authzen.sgnlapis
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen.sgnlapis.cloud markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/results/topaz.md
+++ b/interop/authzen-interop-website/docs/results/topaz.md
@@ -13,45 +13,959 @@ yarn test https://authzen-topaz-proxy.demo.aserto.com markdown
 yarn run v1.22.19
 $ node build/test/runner.js https://authzen-topaz-proxy.demo.aserto.com markdown
 ```
-| result | request |
-| --- | --- |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"rick@the-citadel.com","userID":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"rick@the-citadel.com","identity":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"morty@the-citadel.com","userID":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"morty@the-citadel.com","identity":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"morty@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"summer@the-smiths.com","userID":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"summer@the-smiths.com","identity":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"summer@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"beth@the-smiths.com","identity":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"beth@the-smiths.com","userID":"beth@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_user"},"resource":{"type":"user","id":"jerry@the-smiths.com","userID":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_read_todos"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_create_todo"},"resource":{"type":"todo","id":"todo-1"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_update_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"rick@the-citadel.com"}}` |
-| PASS | `{"subject":{"type":"user","id":"jerry@the-smiths.com","identity":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"},"action":{"name":"can_delete_todo"},"resource":{"type":"todo","id":"7240d0db-8ff0-41ec-98b2-34a096273b9f","ownerID":"jerry@the-smiths.com"}}` |
+<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "rick@the-citadel.com",
+    "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "morty@the-citadel.com",
+    "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "morty@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "summer@the-smiths.com",
+    "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "summer@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "beth@the-smiths.com",
+    "userID": "beth@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_user"
+  },
+  "resource": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_read_todos"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_create_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "todo-1"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_update_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "rick@the-citadel.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+  <tr>
+    <td bgColor="green">PASS</td>
+    <td>
+
+```js
+{
+  "subject": {
+    "type": "user",
+    "id": "jerry@the-smiths.com",
+    "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+  },
+  "action": {
+    "name": "can_delete_todo"
+  },
+  "resource": {
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "ownerID": "jerry@the-smiths.com"
+  }
+}
+```
+
+  </td>
+  </tr>
+</table>

--- a/interop/authzen-interop-website/docs/scenarios/todo.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo.md
@@ -72,7 +72,7 @@ This will be extracted from the `sub` claim in the JWT passed in as a bearer tok
 These are noted below in JSON format, with the key being the PID string from the table above, and the value being a set of attributes associated with the user. 
 
 
-```json
+```js
 {
   "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
     "id": "rick@the-citadel.com",
@@ -124,7 +124,7 @@ For simplicity, the policy always returns `true`.
 
 #### Request payload
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -152,7 +152,7 @@ For simplicity, the policy always returns `true`.
 
 For every subject and resource combination:
 
-```json
+```js
 {
   "decision": true
 }
@@ -166,7 +166,7 @@ For simplicity, the policy always returns `true` for every user.
 
 #### Request payload
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -193,7 +193,7 @@ For simplicity, the policy always returns `true` for every user.
 
 For every subject and resource combination:
 
-```json
+```js
 {
   "decision": true
 }
@@ -207,7 +207,7 @@ The policy evaluates the subject's `roles` attribute to determine whether the us
 
 #### Request payload
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -234,7 +234,7 @@ The policy evaluates the subject's `roles` attribute to determine whether the us
 
 Only users with a `roles` attribute that contains `admin` or `editor` return a `true` decision. In the user set above, this includes Rick, Morty, and Summer.
 
-```json
+```js
 {
   "decision": true
 }
@@ -242,7 +242,7 @@ Only users with a `roles` attribute that contains `admin` or `editor` return a `
 
 For the other two users, Beth and Jerry, the decision is `false`.
 
-```json
+```js
 {
   "decision": false
 }
@@ -258,7 +258,7 @@ The `resource` contains an attribute called `ownerID` which contains the `id` of
 
 #### Request payload
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -288,7 +288,7 @@ Only users with a `roles` attribute that contains `evil_genius` (Rick), OR the o
 
 For the user Morty, the following request will return a `true` decision:
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -308,7 +308,7 @@ For the user Morty, the following request will return a `true` decision:
 }
 ```
 
-```json
+```js
 {
   "decision": true
 }
@@ -316,7 +316,7 @@ For the user Morty, the following request will return a `true` decision:
 
 For a different value of `ownerID`, the decision will be `false`:
 
-```json
+```js
 {
   "decision": false
 }
@@ -333,7 +333,7 @@ The `resource` contains an attribute called `ownerID` which contains the `id` of
 
 #### Request payload
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -363,7 +363,7 @@ Only users with a `roles` attribute that contains `admin` (Rick), OR the owner o
 
 For the user Morty, the following request will return a `true` decision:
 
-```json
+```js
 {
   "subject": {
     "type": "user",
@@ -383,7 +383,7 @@ For the user Morty, the following request will return a `true` decision:
 }
 ```
 
-```json
+```js
 {
   "decision": true
 }
@@ -391,7 +391,7 @@ For the user Morty, the following request will return a `true` decision:
 
 For a different value of `ownerID`, the decision will be `false`:
 
-```json
+```js
 {
   "decision": false
 }

--- a/interop/authzen-todo-backend/test/runner.ts
+++ b/interop/authzen-todo-backend/test/runner.ts
@@ -1,6 +1,7 @@
 import clc from "cli-color";
 
 import { decisions } from "./decisions.json";
+import { json } from "stream/consumers";
 
 const AUTHZEN_PDP_URL =
   process.argv[2] || "https://authzen-proxy.demo.aserto.com";
@@ -69,7 +70,7 @@ async function main() {
         results.map((d) => {
           return {
             result: d.status,
-            request: JSON.stringify(d.request),
+            request: JSON.stringify(d.request, null, 2),
           };
         })
       )
@@ -99,39 +100,29 @@ function logResult(result: Result) {
   }
 }
 
-/* inspired by https://github.com/nijikokun/array-to-table/blob/master/index.js */
-function arrayToTable (array, columns?, alignment = 'center') {
-  var table = ""
-  var separator = {
-    'left': ':---',
-    'right': '---:',
-    'center': '---'
-  }
-
-  // Generate column list
-  var cols = columns
-    ? columns.split(",")
-    : Object.keys(array[0])
-
-  // Generate table headers
-  table += `| ${cols.join(' | ')} |\r\n`
-
-  // Generate table header seperator
-  table += `| ${cols.map(function () {
-    return separator[alignment] || separator.center
-  }).join(' | ')} |\r\n`
-
+function arrayToTable (array) {
+  var cols = Object.keys(array[0])
+  var table = `<table>
+  <tr>
+    <th>result</th>
+    <th>request</th>
+  </tr>
+`
   // Generate table body
   array.forEach(function (item) {
+    const bgColor = item.result ? 'green' : 'red'
+    table += `  <tr>
+    <td bgColor="${bgColor}">${String(item.result)}</td>
+    <td>
 
-    table += `| ${cols.map(function (key) {
-      if (key === 'request') {
-        return '`' + String(item[key] || '') + '`'
-      } else {
-        return String(item[key] || '')
-      }
-    }).join(' | ')} |\r\n`
+`
+    table += "```js\r\n" + item.request + "\r\n```\r\n\r\n"
+    table += `  </td>
+  </tr>
+`
   })
+
+  table += "</table>"
 
   // Return table
   return table


### PR DESCRIPTION
* improve test runner markdown generator to create something much more viewable in docusaurus, using <table> tags
* re-generate all 13 results pages
