### PR TITLE
initial commit for implementers draft changes

### DIFF
--- a/interop/authzen-todo-application/.env
+++ b/interop/authzen-todo-application/.env
@@ -2,3 +2,4 @@ REACT_APP_OIDC_DOMAIN=citadel.demo.aserto.com
 REACT_APP_OIDC_CLIENT_ID=citadel-app
 REACT_APP_OIDC_AUDIENCE=citadel-app
 REACT_APP_API_ORIGIN=https://authzen-todo-backend.demo.aserto.com
+REACT_APP_API_ORIGIN=http://localhost:8080

--- a/interop/authzen-todo-application/src/App.tsx
+++ b/interop/authzen-todo-application/src/App.tsx
@@ -2,7 +2,7 @@ import { useAuth } from "oidc-react";
 import React, { useCallback, useEffect, useState } from "react";
 import { ToastContainer, toast } from "react-toastify";
 import { Todos } from "./components/Todos";
-import { AppProps, Todo, User } from "./interfaces";
+import { AppProps, Todo, User, Config } from "./interfaces";
 import { useTodoService, useUser } from "./todoService";
 import Select from "react-select";
 
@@ -32,18 +32,32 @@ type PDP = {
   name: string;
 };
 
+type SpecVersion = {
+  name: string;
+};
+
 export const App: React.FC<AppProps> = (props) => {
   const auth = useAuth();
-  const { createTodo, listTodos, listPdps, setPdp } = useTodoService();
+  const {
+    createTodo,
+    listTodos,
+    getConfig,
+    pdp,
+    specVersion,
+    setPdp,
+    setSpecVersion,
+  } = useTodoService();
   const userEmail = props.user.email;
   const [todos, setTodos] = useState<Todo[] | void>([]);
+  const [config, setConfig] = useState<Config>();
   const [pdps, setPdps] = useState<PDP[]>([]);
+  const [specVersions, setSpecVersions] = useState<SpecVersion[]>([]);
   const [todoTitle, setTodoTitle] = useState<string>("");
   const [showCompleted, setShowCompleted] = useState<boolean>(true);
   const [showActive, setShowActive] = useState<boolean>(true);
   const user: User = useUser(props.user.sub);
-  const storedPdpOption = localStorage.getItem("pdp");
-  const currentPdpOption = storedPdpOption ? { name: storedPdpOption } : (pdps && pdps[0]);
+  const [currentPdpOption, setCurrentPdpOption] = useState<PDP>({ name: pdp });
+  const [currentSpecVersion, setCurrentSpecVersion] = useState<SpecVersion>({ name: specVersion });
 
   const errorHandler = (errorText: string, close?: number | false) => {
     const autoClose = close === undefined ? 3000 : close;
@@ -114,15 +128,32 @@ export const App: React.FC<AppProps> = (props) => {
     setShowCompleted(false);
   };
 
-  const getPdps: () => void = useCallback(() => {
+  const getSpecVersionsAndPdps: () => void = useCallback(async () => {
     const list = async () => {
       try {
-        const pdps: string[] = await listPdps();
+        const config: Config = await getConfig();
+        setConfig(config);
+        const defaultSpecVersion = localStorage.getItem("specVersion") ?? Object.keys(config)[0];
+        setSpecVersions(
+          Object.keys(config).map((v) => {
+            return { name: v };
+          })
+        );
+        if (!specVersion) {
+          setSpecVersion(defaultSpecVersion);
+          setCurrentSpecVersion({ name: defaultSpecVersion });
+        }
+        const pdps = config[defaultSpecVersion];
+        const defaultPdp = localStorage.getItem("pdp") ?? pdps[0];
         setPdps(
           pdps.map((pdp) => {
             return { name: pdp };
           })
         );
+        if (!pdp) {
+          setPdp(defaultPdp);
+          setCurrentPdpOption({ name: defaultPdp });
+        }
       } catch (e) {
         if (e instanceof TypeError && e.message === "Failed to fetch") {
           errorHandler("", false);
@@ -131,18 +162,45 @@ export const App: React.FC<AppProps> = (props) => {
     };
 
     list();
-  }, [listPdps]);
+  }, [getConfig, pdp, specVersion, setPdp, setPdps, setSpecVersion, setSpecVersions]);
 
-  const storePdp: ((pdp: string) => void) = useCallback((pdp: string) => {
-    setPdp(pdp);
-    localStorage.setItem("pdp", pdp);
-  }, [setPdp])
+  const storePdp: (pdp: string) => void = useCallback(
+    (pdp: string) => {
+      setPdp(pdp);
+      setCurrentPdpOption({ name: pdp });
+      localStorage.setItem("pdp", pdp);
+    },
+    [setPdp]
+  );
+
+  const storeSpecVersion: (version: string) => void = useCallback(
+    (version: string) => {
+      setSpecVersion(version);
+      setCurrentSpecVersion({ name: version });
+      localStorage.setItem("specVersion", version);
+      const pdps = config && config[version];
+      if (pdps) {
+        setPdps(
+          pdps.map((pdp) => {
+            return { name: pdp };
+          })
+        );
+        storePdp(pdps[0]);
+      }
+    },
+    [config, setSpecVersion, setPdps, storePdp]
+  );
 
   useEffect(() => {
-    getPdps();
-    refreshTodos();
+    getSpecVersionsAndPdps();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (specVersion && pdp) {
+      refreshTodos();
+    }
+  }, [refreshTodos, specVersion, pdp])
 
   return (
     <div className="App">
@@ -218,13 +276,27 @@ export const App: React.FC<AppProps> = (props) => {
         <div className="user-controls">
           <>
             <div className="pdp-info">
-              <span className="user-name">Authorize using: &nbsp;</span>
+              <span className="select-title">AuthZEN version: &nbsp;</span>
+              {pdps.length && (
+                <Select
+                  className="pdp-select"
+                  isSearchable={false}
+                  options={specVersions}
+                  value={currentSpecVersion}
+                  getOptionLabel={(version: SpecVersion) => version.name}
+                  getOptionValue={(version: SpecVersion) => version.name}
+                  onChange={(option) => storeSpecVersion(option!.name)}
+                />
+              )}
+            </div>
+            <div className="pdp-info">
+              <span className="select-title">Authorize using: &nbsp;</span>
               {pdps.length && (
                 <Select
                   className="pdp-select"
                   isSearchable={false}
                   options={pdps}
-                  defaultValue={currentPdpOption}
+                  value={currentPdpOption}
                   getOptionLabel={(pdp: PDP) => pdp.name}
                   getOptionValue={(pdp: PDP) => pdp.name}
                   onChange={(option) => storePdp(option!.name)}

--- a/interop/authzen-todo-application/src/App.tsx
+++ b/interop/authzen-todo-application/src/App.tsx
@@ -103,7 +103,7 @@ export const App: React.FC<AppProps> = (props) => {
     refreshTodos();
   };
 
-  const refreshTodos: () => void = useCallback(() => {
+  const refreshTodos: () => void = () => {
     const getTodos = async () => {
       try {
         const todos: Todo[] = await listTodos();
@@ -116,7 +116,7 @@ export const App: React.FC<AppProps> = (props) => {
     };
 
     getTodos();
-  }, [listTodos]);
+  };
 
   const enableShowCompleted: () => void = () => {
     setShowCompleted(true);
@@ -200,7 +200,8 @@ export const App: React.FC<AppProps> = (props) => {
     if (specVersion && pdp) {
       refreshTodos();
     }
-  }, [refreshTodos, specVersion, pdp])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [specVersion, pdp])
 
   return (
     <div className="App">

--- a/interop/authzen-todo-application/src/LoginWrapper.tsx
+++ b/interop/authzen-todo-application/src/LoginWrapper.tsx
@@ -11,7 +11,8 @@ export function LoginWrapper() {
   const { userData } = auth;
   const isAuthenticated = userData?.id_token ? true : false;
   const [loggedIn, setLoggedIn] = useState(false);
-  const [pdp, setPdp] = useState<string>(localStorage.getItem("pdp") ?? "");
+  const [specVersion, setSpecVersion] = useState<string>("");
+  const [pdp, setPdp] = useState<string>("");
 
   useEffect(() => {
     if (!auth.isLoading && !isAuthenticated) {
@@ -25,7 +26,13 @@ export function LoginWrapper() {
   if (loggedIn && userData?.profile.email) {
     return (
       <QueryClientProvider client={queryClient}>
-        <TodoService token={userData.id_token} pdp={pdp} setPdp={setPdp}>
+        <TodoService
+          token={userData.id_token}
+          pdp={pdp}
+          specVersion={specVersion}
+          setPdp={setPdp}
+          setSpecVersion={setSpecVersion}
+        >
           <App
             user={{
               email: userData.profile.email,

--- a/interop/authzen-todo-application/src/components/Todo.tsx
+++ b/interop/authzen-todo-application/src/components/Todo.tsx
@@ -10,6 +10,7 @@ export const Todo: React.FC<TodoProps> = (todoProps) => {
       <div className="view">
         <input
           className="toggle"
+          disabled={!!todoProps.todo.CannotUpdate}
           type="checkbox"
           onChange={() =>
             todoProps.handleCompletedChange(

--- a/interop/authzen-todo-application/src/index.css
+++ b/interop/authzen-todo-application/src/index.css
@@ -49,4 +49,29 @@ code {
 
 .pdp-select {
   min-width: 300px;
+  font-size: 20px;
+}
+
+.select-title {
+  min-width: 250px;
+}
+
+/* from todomvc-app-css/index.css */
+/* override disabled styles to grey out the toggle */
+.todo-list li .toggle:disabled + label {
+	/*
+		Firefox requires `#` to be escaped - https://bugzilla.mozilla.org/show_bug.cgi?id=922433
+		IE and Edge requires *everything* to be escaped to render, so we do that instead of just the `#` - https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7157459/
+	*/
+	background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22%23eeeeee%22%20stroke%3D%22%23949494%22%20stroke-width%3D%221%22/%3E%3C/svg%3E');
+	background-repeat: no-repeat;
+	background-position: center left;
+}
+
+.todo-list li .toggle:checked:disabled + label {
+	background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22%23eeeeee%22%20stroke%3D%22%2359A193%22%20stroke-width%3D%221%22%2F%3E%3Cpath%20fill%3D%22%233EA390%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22%2F%3E%3C%2Fsvg%3E');
+}
+
+.todo-list li .toggle:disabled {
+  cursor: not-allowed;
 }

--- a/interop/authzen-todo-application/src/interfaces.ts
+++ b/interop/authzen-todo-application/src/interfaces.ts
@@ -6,6 +6,7 @@ export interface TodoValues {
 export interface Todo extends TodoValues {
   ID: string;
   OwnerID: string;
+  CannotUpdate?: boolean;
 }
 
 export interface User {
@@ -21,8 +22,11 @@ export interface ITodoService {
   saveTodo: (id: string, values: TodoValues) => Promise<Todo[]>;
   deleteTodo: (todo: Todo) => Promise<void | Response>;
   getUser: (sub: string) => Promise<User>;
-  listPdps: () => Promise<string[]>;
+  getConfig: () => Promise<Config>;
   setPdp: (pdp: string) => void;
+  setSpecVersion: (specVersion: string) => void;
+  pdp: string
+  specVersion: string
 }
 
 export interface TodoProps {
@@ -46,4 +50,8 @@ export interface AppProps {
 export interface AuthUser {
   email: string;
   sub: string;
+}
+
+export type Config = {
+  [specVersion: string]: string[]
 }

--- a/interop/authzen-todo-backend/src/index.ts
+++ b/interop/authzen-todo-backend/src/index.ts
@@ -19,11 +19,36 @@ Store.open().then((store) => {
   const checkAuthz = authzMiddleware(store);
 
   app.get("/pdps", server.listPdps.bind(server));
-  app.get("/users/:userID", checkJwt, checkAuthz('can_read_user'), server.getUser.bind(server));
-  app.get("/todos", checkJwt, checkAuthz('can_read_todos'), server.list.bind(server));
-  app.post("/todos", checkJwt, checkAuthz('can_create_todo'), server.create.bind(server));
-  app.put("/todos/:id", checkJwt, checkAuthz('can_update_todo'), server.update.bind(server));
-  app.delete("/todos/:id", checkJwt, checkAuthz('can_delete_todo'), server.delete.bind(server));
+  app.get(
+    "/users/:userID",
+    checkJwt,
+    checkAuthz("can_read_user"),
+    server.getUser.bind(server)
+  );
+  app.get(
+    "/todos",
+    checkJwt,
+    checkAuthz("can_read_todos"),
+    server.list.bind(server)
+  );
+  app.post(
+    "/todos",
+    checkJwt,
+    checkAuthz("can_create_todo"),
+    server.create.bind(server)
+  );
+  app.put(
+    "/todos/:id",
+    checkJwt,
+    checkAuthz("can_update_todo"),
+    server.update.bind(server)
+  );
+  app.delete(
+    "/todos/:id",
+    checkJwt,
+    checkAuthz("can_delete_todo"),
+    server.delete.bind(server)
+  );
 
   app.listen(PORT, () => {
     console.log(`⚡️[server]: Server is running at http://localhost:${PORT}`);

--- a/interop/authzen-todo-backend/src/interfaces.d.ts
+++ b/interop/authzen-todo-backend/src/interfaces.d.ts
@@ -3,6 +3,7 @@ export interface Todo {
   Title: string;
   Completed: boolean;
   OwnerID: string;
+  CannotUpdate?: boolean;
 }
 
 export interface User {

--- a/interop/authzen-todo-backend/src/pdps.json
+++ b/interop/authzen-todo-backend/src/pdps.json
@@ -1,21 +1,23 @@
 {
   "1.0-preview": {
-    "Aserto": "https://authzen-proxy.demo.aserto.com",
+    "Aserto": "https://authzen-proxy-preview.demo.aserto.com",
     "Axiomatics": "https://pdp.alfa.guide",
     "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
     "HexaOPA": "https://interop.authzen.hexaorchestration.org",
     "Kogito": "https://authzen-proxy-demo.azerad.org",
-    "Open Policy Agent": "https://authzen-opa-proxy.demo.aserto.com",
+    "Open Policy Agent": "https://authzen-opa-proxy-preview.demo.aserto.com",
     "Permit.io": "https://permit-authzen-interop.up.railway.app",
     "PlainID": "https://authzeninteropt.se-plainid.com",
     "Rock Solid Knowledge": "https://authzen.identityserver.com",
     "SGNL": "https://authzen.sgnlapis.cloud",
     "Thales AuthZForce": "https://restful-pdp-vji43cydea-uc.a.run.app",
-    "Topaz": "https://authzen-topaz-proxy.demo.aserto.com",
+    "Topaz": "https://authzen-topaz-proxy-preview.demo.aserto.com",
     "3Edges": "https://api-authzen-authz.3edges.io"
   },
   "1.0-implementers-draft": {
-    "Aserto": "https://authzen-proxy.demo.aserto.com"
+    "Aserto": "https://authzen-proxy.demo.aserto.com",
+    "Open Policy Agent": "https://authzen-opa-proxy.demo.aserto.com",
+    "Topaz": "https://authzen-topaz-proxy.demo.aserto.com"
   },
   "1.1-preview": {
     "Cerbos": "https://authzen-proxy-demo.cerbos.dev"

--- a/interop/authzen-todo-backend/src/pdps.json
+++ b/interop/authzen-todo-backend/src/pdps.json
@@ -1,15 +1,23 @@
 {
-  "Aserto": "https://authzen-proxy.demo.aserto.com",
-  "Axiomatics": "https://pdp.alfa.guide",
-  "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
-  "HexaOPA": "https://interop.authzen.hexaorchestration.org",
-  "Kogito": "https://authzen-proxy-demo.azerad.org",
-  "Open Policy Agent": "https://authzen-opa-proxy.demo.aserto.com",
-  "Permit.io": "https://permit-authzen-interop.up.railway.app",
-  "PlainID": "https://authzeninteropt.se-plainid.com",
-  "Rock Solid Knowledge": "https://authzen.identityserver.com",
-  "SGNL": "https://authzen.sgnlapis.cloud",
-  "Thales AuthZForce": "https://restful-pdp-vji43cydea-uc.a.run.app",
-  "Topaz": "https://authzen-topaz-proxy.demo.aserto.com",
-  "3Edges": "https://api-authzen-authz.3edges.io"
+  "1.0-preview": {
+    "Aserto": "https://authzen-proxy.demo.aserto.com",
+    "Axiomatics": "https://pdp.alfa.guide",
+    "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
+    "HexaOPA": "https://interop.authzen.hexaorchestration.org",
+    "Kogito": "https://authzen-proxy-demo.azerad.org",
+    "Open Policy Agent": "https://authzen-opa-proxy.demo.aserto.com",
+    "Permit.io": "https://permit-authzen-interop.up.railway.app",
+    "PlainID": "https://authzeninteropt.se-plainid.com",
+    "Rock Solid Knowledge": "https://authzen.identityserver.com",
+    "SGNL": "https://authzen.sgnlapis.cloud",
+    "Thales AuthZForce": "https://restful-pdp-vji43cydea-uc.a.run.app",
+    "Topaz": "https://authzen-topaz-proxy.demo.aserto.com",
+    "3Edges": "https://api-authzen-authz.3edges.io"
+  },
+  "1.0-implementers-draft": {
+    "Aserto": "https://authzen-proxy.demo.aserto.com"
+  },
+  "1.1-preview": {
+    "Cerbos": "https://authzen-proxy-demo.cerbos.dev"
+  }
 }

--- a/interop/authzen-todo-backend/src/server.ts
+++ b/interop/authzen-todo-backend/src/server.ts
@@ -4,6 +4,7 @@ import { Response } from "express";
 import { Todo } from "./interfaces";
 import { Store } from "./store";
 import { Directory } from "./directory";
+import { checkCanUpdateTodos } from "./auth";
 const pdps = require("./pdps.json");
 
 export class Server {
@@ -16,7 +17,12 @@ export class Server {
   }
 
   async listPdps(_: Request, res: Response) {
-    res.json(Object.keys(pdps));
+    const config = {};
+    const versions = Object.keys(pdps);
+    for (const v of versions) {
+      config[v] = Object.keys(pdps[v])
+    }
+    res.json(config);
   }
 
   async getUser(req: JWTRequest, res: Response) {
@@ -28,8 +34,9 @@ export class Server {
     }
   }
 
-  async list(_: Request, res: Response) {
-    const todos = await this.store.list();
+  async list(req: JWTRequest, res: Response) {
+    let todos = await this.store.list();
+    todos = await checkCanUpdateTodos(req, todos);
     res.json(todos);
   }
 

--- a/interop/authzen-todo-backend/test/decisions-1.0-implementers-draft.json
+++ b/interop/authzen-todo-backend/test/decisions-1.0-implementers-draft.json
@@ -1,0 +1,706 @@
+{
+  "evaluation": [
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "summer@the-smiths.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "summer@the-smiths.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "beth@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "beth@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "jerry@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id":"CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "jerry@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/interop/authzen-todo-backend/test/decisions-1.0-preview.json
+++ b/interop/authzen-todo-backend/test/decisions-1.0-preview.json
@@ -1,0 +1,716 @@
+{
+  "evaluation": [
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "userID": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "userID": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "userID": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "userID": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "userID": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "userID": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "summer@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com",
+          "identity": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "summer@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "userID": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "userID": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "beth@the-smiths.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "identity": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "beth@the-smiths.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com",
+          "userID": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "userID": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "jerry@the-smiths.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "rick@the-citadel.com"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "ownerID": "jerry@the-smiths.com"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/interop/authzen-todo-backend/test/decisions-1.1-preview.json
+++ b/interop/authzen-todo-backend/test/decisions-1.1-preview.json
@@ -1,0 +1,807 @@
+{
+  "evaluation": [
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "summer@the-smiths.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "summer@the-smiths.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "beth@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "beth@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "jerry@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+          "properties": {
+            "ownerID": "jerry@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    }
+  ],
+  "evaluations": [
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "identity": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "evaluations": {
+          "1": {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+              "properties": {
+                "ownerID": "rick@the-citadel.com"
+              }
+            }
+          },
+          "2": {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+              "properties": {
+                "ownerID": "jerry@the-smiths.com"
+              }
+            }
+          }
+        }
+      },
+      "expected": { "1": { "decision": true }, "2": { "decision": true } }
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "identity": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "evaluations": {
+          "1": {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+              "properties": {
+                "ownerID": "rick@the-citadel.com"
+              }
+            }
+          },
+          "2": {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+              "properties": {
+                "ownerID": "morty@the-citadel.com"
+              }
+            }
+          }
+        }
+      },
+      "expected": { "1": { "decision": false }, "2": { "decision": true } }
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "identity": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "evaluations": {
+          "1": {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+              "properties": {
+                "ownerID": "rick@the-citadel.com"
+              }
+            }
+          },
+          "2": {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+              "properties": {
+                "ownerID": "jerry@the-smiths.com"
+              }
+            }
+          }
+        }
+      },
+      "expected": { "1": { "decision": false }, "2": { "decision": false } }
+    }
+  ]
+}

--- a/interop/authzen-todo-backend/test/runner.ts
+++ b/interop/authzen-todo-backend/test/runner.ts
@@ -1,7 +1,5 @@
 import clc from "cli-color";
-
-import { decisions } from "./decisions.json";
-import { json } from "stream/consumers";
+import { evaluation } from "./decisions-1.0-implementers-draft.json";
 
 const AUTHZEN_PDP_URL =
   process.argv[2] || "https://authzen-proxy.demo.aserto.com";
@@ -13,55 +11,55 @@ enum OutputTypes {
 }
 
 const FORMAT =
-  process.argv[3] === "markdown" ? OutputTypes.MARKDOWN : OutputTypes.CONSOLE;
+  process.argv[4] === "markdown" ? OutputTypes.MARKDOWN : OutputTypes.CONSOLE;
+
+type Endpoint = "evaluation" | "evaluations";
 
 interface Result {
-  request: (typeof decisions)[number]["request"];
-  expected: (typeof decisions)[0]["expected"];
+  endpoint: Endpoint;
+  request: (typeof evaluation)[number]["request"];
+  expected: (typeof evaluation)[0]["expected"];
   response?: boolean;
   status: "PASS" | "FAIL" | "ERROR";
   error?: string;
 }
 
 async function main() {
+  if (process.argv.length < 3) {
+    console.log(`Usage: yarn test <authorizer-url> [<spec-version>] [<format>]
+
+    <spec-version> should be one of:
+      1.0-preview
+      1.0-implementers-draft
+      1.1-preview
+
+      and defaults to 1.0-implementers-draft
+
+    <format> should be one of:
+      console
+      markdown
+
+      and defaults to markdown
+  `);
+    process.exit(0);
+  }
+
+  const decisionFile =
+    process.argv.length >= 4
+      ? `./decisions-${process.argv[3]}.json`
+      : "./decisions-1.0-implementers-draft.json";
+  const { evaluation, evaluations } = require(decisionFile);
+
   const results: Result[] = [];
 
-  for (const decision of decisions) {
-    const REQ = decision.request;
-    const EXP = decision.expected;
-    try {
-      const response = await fetch(`${AUTHZEN_PDP_URL}/access/v1/evaluation`, {
-        method: "POST",
-        headers: {
-          Authorization: AUTHZEN_PDP_API_KEY,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(REQ),
-      });
+  for (const decision of evaluation || []) {
+    const result = await execute(decision, "evaluation");
+    results.push(result);
+  }
 
-      const data = await response.json();
-      const RSP = data.decision || false;
-
-      const result: Result = {
-        request: REQ,
-        response: RSP,
-        expected: EXP,
-        status: JSON.stringify(EXP) === JSON.stringify(RSP) ? "PASS" : "FAIL",
-      };
-
-      results.push(result);
-      if (FORMAT === OutputTypes.CONSOLE) logResult(result);
-    } catch (error) {
-      const result: Result = {
-        request: REQ,
-        expected: EXP,
-        status: "ERROR",
-        error: error.message,
-      };
-
-      results.push(result);
-      if (FORMAT === OutputTypes.CONSOLE) logResult(result);
-    }
+  for (const decision of evaluations || []) {
+    const result = await execute(decision, "evaluations");
+    results.push(result);
   }
 
   if (FORMAT === OutputTypes.MARKDOWN) {
@@ -75,6 +73,51 @@ async function main() {
         })
       )
     );
+  }
+}
+
+async function execute(
+  decision: (typeof evaluation)[number],
+  endpoint: Endpoint
+): Promise<Result> {
+  const REQ = decision.request;
+  const EXP = decision.expected;
+  try {
+    const response = await fetch(`${AUTHZEN_PDP_URL}/access/v1/${endpoint}`, {
+      method: "POST",
+      headers: {
+        Authorization: AUTHZEN_PDP_API_KEY,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(REQ),
+    });
+
+    const data = await response.json();
+    const RSP =
+      endpoint === "evaluation"
+        ? data.decision || false
+        : data.evaluations || [];
+
+    const result: Result = {
+      endpoint,
+      request: REQ,
+      response: RSP,
+      expected: EXP,
+      status: JSON.stringify(EXP) === JSON.stringify(RSP) ? "PASS" : "FAIL",
+    };
+
+    if (FORMAT === OutputTypes.CONSOLE) logResult(result);
+    return result;
+  } catch (error) {
+    const result: Result = {
+      endpoint,
+      request: REQ,
+      expected: EXP,
+      status: "ERROR",
+      error: error.message,
+    };
+    if (FORMAT === OutputTypes.CONSOLE) logResult(result);
+    return result;
   }
 }
 
@@ -100,32 +143,32 @@ function logResult(result: Result) {
   }
 }
 
-function arrayToTable (array) {
-  var cols = Object.keys(array[0])
+function arrayToTable(array) {
+  var cols = Object.keys(array[0]);
   var table = `<table>
   <tr>
     <th>result</th>
     <th>request</th>
   </tr>
-`
+`;
   // Generate table body
   array.forEach(function (item) {
-    const bgColor = item.result ? 'green' : 'red'
+    const bgColor = item.result ? "green" : "red";
     table += `  <tr>
     <td bgColor="${bgColor}">${String(item.result)}</td>
     <td>
 
-`
-    table += "```js\r\n" + item.request + "\r\n```\r\n\r\n"
+`;
+    table += "```js\r\n" + item.request + "\r\n```\r\n\r\n";
     table += `  </td>
   </tr>
-`
-  })
+`;
+  });
 
-  table += "</table>"
+  table += "</table>";
 
   // Return table
-  return table
+  return table;
 }
 
 main();

--- a/interop/authzen-todo-backend/tsconfig.json
+++ b/interop/authzen-todo-backend/tsconfig.json
@@ -12,6 +12,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", "test/**/*.json"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Changes required to make interop scenario work with the 1.0 implementer's draft.

Front-end:
* added spec version selector in front-end
* prepped for 1.1 by adding a "CannotUpdate" field to each Todo returned, which shows a disabled update button
* send specversion and pdp with each request to the backend

Back-end:
* pdps.json now organizes implementations based on spec version - "1.0-preview", "1.0-implementers-draft", and "1.1-preview"
* the "1.1-preview" will make an `evaluations` call to a compliant back-end to determine whether a user can update each of the todos
* the todo list is enhanced with the CannotUpdate field if the user doesn't have permission to update the todo

The App is compatible with all three types of implementations - existing, 1.0-implementers-draft compliant, and 1.1 preview.
