### PR TITLE
updated spec URLs and readme/docs

### DIFF
--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -5,7 +5,7 @@ cat: std # Check
 submissiontype: IETF
 wg: OpenID AuthZEN
 
-docname: authorization-api-1_0_02
+docname: authorization-api-1_0
 
 title: Authorization API 1.0 – draft 02
 abbrev: azapi

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/index.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/index.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 This document lists the request and response payloads for each of the API requests in the Todo interop scenario.
 
-> Note: These payloads and corresponding interop results are for the [AuthZEN 1.0 Implementers Draft](https://openid.github.io/authzen/authorization-api-1_0_01) version of the spec.
+> Note: These payloads and corresponding interop results are for the [AuthZEN 1.0 Implementers Draft](https://openid.net/specs/authorization-api-1_0-01.html) version of the spec.
 
 :::tip
 This is a copy of the payload document defined by the AuthZEN WG. The definitive document can be found [here](https://hackmd.io/gNZBRoTfRgWh_PNM0y2wDA?view).

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.1/index.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.1/index.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 This document lists the request and response payloads for each of the API requests in the Todo interop scenario.
 
-> Note: These payloads and corresponding interop results are for the [AuthZEN 1.1 Preview 01](https://openid.github.io/authzen/authorization-api-1_1_01) version of the spec.
+> Note: These payloads and corresponding interop results are for the [AuthZEN 1.0 Draft 02](https://openid.github.io/authzen) version of the spec.
 
 :::tip
 This is a copy of the payload document defined by the AuthZEN WG. The definitive document can be found [here](https://hackmd.io/gNZBRoTfRgWh_PNM0y2wDA?view).

--- a/interop/authzen-interop-website/docs/scenarios/todo/index.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 This document lists the request and response payloads for each of the API requests in the Todo interop scenario.
 
-:::danger These payloads and corresponding interop results are for the [AuthZEN 1.0 Preview 00](https://openid.github.io/authzen/authorization-api-1_0_00) version of the spec. These results are superseded by the [Implementers Draft](../todo-1.0-id/index.md) results. Once all of the implementations in this section switch over to the Implementers Draft, this section will be deleted.
+:::danger These payloads and corresponding interop results are for the [AuthZEN 1.0 Preview 00](https://openid.net/specs/authorization-api-1_0-00.html) version of the spec. These results are superseded by the [Implementers Draft](../todo-1.0-id/index.md) results. Once all of the implementations in this section switch over to the Implementers Draft, this section will be deleted.
 :::
 
 :::tip

--- a/interop/authzen-todo-backend/README.md
+++ b/interop/authzen-todo-backend/README.md
@@ -14,7 +14,9 @@ yarn
 
 Rename the `.env.example` file to `.env` and update the `AUTHZEN_PDP_URL` variable. The authorization middleware will send AuthZEN requests to `${AUTHZEN_PDP_URL}/access/v1/evaluation` (for the `1.0-preview` and `1.0-implementers-draft` spec variations), and to a both `${AUTHZEN_PDP_URL}/access/v1/evaluation` and `${AUTHZEN_PDP_URL}/access/v1/evaluations` (for the `1.1-preview` spec variation).
 
-Optionally, set the `AUTHZEN_PDP_API_KEY` variable if your authorizer needs an API key. You should prefix it with `basic` or `Bearer` as appropriate. If set, the authorization middleware will add the `authorization: ${AUTHZEN_PDP_API_KEY}` header to every authorization request.
+Optionally, set the `AUTHZEN_PDP_API_KEY` variable if your authorizer needs an API key. This variable expects a JSON object with the key being the same keys as you use for your PDP in `src/pdps.json`, and the value being your API key, prefixed with `Basic` or `Bearer` as appropriate. If set, the authorization middleware will add the `Authorization` header with your API key to every authorization request.
+
+Example `.env` file:
 
 ```shell
 JWKS_URI=https://citadel.demo.aserto.com/dex/keys
@@ -22,7 +24,7 @@ ISSUER=https://citadel.demo.aserto.com/dex
 AUDIENCE=citadel-app
 
 AUTHZEN_PDP_URL=https://authorizer.domain.com
-AUTHZEN_PDP_API_KEY=basic YOUR_API_KEY
+AUTHZEN_PDP_API_KEY='{"Aserto":"Basic aserto-key","your-pdp":"Bearer your-key"}'
 ```
 
 ## Start the server in developer mode


### PR DESCRIPTION
* Update spec URLs in interop website to reflect stable spec URLs
* Update README in interop backend to reflect correct API_KEY variable format
* Update API document name to the non-revisioned name