### PR TITLE
add /gatewaypdps endpoint to backend

### DIFF
--- a/interop/authzen-todo-backend/src/index.ts
+++ b/interop/authzen-todo-backend/src/index.ts
@@ -19,6 +19,7 @@ Store.open().then((store) => {
   const checkAuthz = authzMiddleware(store);
 
   app.get("/pdps", server.listPdps.bind(server));
+  app.get("/gatewaypdps", server.listGatewayPdps.bind(server));
   app.get(
     "/users/:userID",
     checkJwt,

--- a/interop/authzen-todo-backend/src/server.ts
+++ b/interop/authzen-todo-backend/src/server.ts
@@ -31,6 +31,10 @@ export class Server {
     res.json(config);
   }
 
+  async listGatewayPdps(_: Request, res: Response) {
+    res.json(pdps.gatewayPdps);
+  }
+
   async getUser(req: JWTRequest, res: Response) {
     const { userID } = req.params;
     if(req.auth.sub === userID) {


### PR DESCRIPTION
This helps gateways dynamically retrieve the set of PDPs that are compliant with the gateway interop spec.
