### PR TITLE
update gateway scenario to use "identity" instead of "user" 

### DIFF
--- a/interop/authzen-api-gateways/aws-api-gateway/authzen.mjs
+++ b/interop/authzen-api-gateways/aws-api-gateway/authzen.mjs
@@ -45,7 +45,7 @@ export async function authorize(req) {
 
   const payload = {
     "subject": {
-      "type": "user",
+      "type": "identity",
       "id": subjectId
     },
     "action": {

--- a/interop/authzen-api-gateways/envoy-gateway/authzen-external-authorizer/authzen.go
+++ b/interop/authzen-api-gateways/envoy-gateway/authzen-external-authorizer/authzen.go
@@ -87,7 +87,7 @@ func (server *AuthServer) AuthorizeRequest(ctx context.Context, request *auth_pb
 	// Create authorization request payload
 	authZENPayload := &AuthZENRequest{
 		Subject: AuthZENSubject{
-			Type: "user",
+			Type: "identity",
 			ID:   userId,
 		},
 		Action: AuthZENAction{

--- a/interop/authzen-api-gateways/kong-gateway/kong/plugins/authzen/access.lua
+++ b/interop/authzen-api-gateways/kong-gateway/kong/plugins/authzen/access.lua
@@ -100,7 +100,7 @@ function _M.execute(conf)
     local id = decoded_token.claims.sub
     local authzen_request = {
         subject = {
-            type = "user",
+            type = "identity",
             id = id
         },
         resource = {

--- a/interop/authzen-api-gateways/test-harness/test/decisions.json
+++ b/interop/authzen-api-gateways/test-harness/test/decisions.json
@@ -3,7 +3,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -19,7 +19,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -35,7 +35,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -51,7 +51,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -67,7 +67,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -84,7 +84,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -100,7 +100,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -116,7 +116,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -132,7 +132,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -148,7 +148,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -165,7 +165,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -181,7 +181,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -197,7 +197,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -213,7 +213,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -229,7 +229,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -246,7 +246,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -262,7 +262,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -278,7 +278,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -294,7 +294,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -310,7 +310,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -327,7 +327,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -343,7 +343,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -359,7 +359,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -375,7 +375,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {
@@ -391,7 +391,7 @@
     {
       "request": {
         "subject": {
-          "type": "user",
+          "type": "identity",
           "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {

--- a/interop/authzen-api-gateways/tyk-gateway/plugins/authzen.go
+++ b/interop/authzen-api-gateways/tyk-gateway/plugins/authzen.go
@@ -87,7 +87,7 @@ func AuthZENMiddleware(w http.ResponseWriter, r *http.Request) {
 
 	authZENPayload := &AuthZENRequest{
 		Subject: AuthZENSubject{
-			Type: "user",
+			Type: "identity",
 			ID:   userId,
 		},
 		Action: AuthZENAction{

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/index.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/index.md
@@ -12,6 +12,10 @@ This document lists the request and response payloads for each of the API reques
 This is a copy of the payload document defined by the AuthZEN WG. The definitive document can be found [here](https://hackmd.io/ecYxP6uxSCm5X0RexkAM2g?view).
 :::
 
+## Changelog
+- Created: Jan 23 2025
+- Updated: Feb 22 2025 (`subject.type`: `"user"` -> `"identity"`)
+
 ## Context
 
 The API Gateway scenario layers on top of the existing Todo scenario.
@@ -92,7 +96,7 @@ This will be extracted from the `sub` claim in the JWT passed in as a bearer tok
 These are noted below in JSON format, with the key being the PID string from the table above, and the value being a set of attributes associated with the user. 
 
 
-```json=
+```js
 {
   "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs": {
     "id": "rick@the-citadel.com",
@@ -138,7 +142,7 @@ The PIP can, of course, express this in any way they desire. The policy for each
 
 Unless otherwise noted, these are payloads for the `evaluation` API, and are meant to be sent using the following HTTP(S) request:
 
-```http=
+```http
 POST /access/v1/evaluation HTTP/1.1
 Host: mypdp.com
 [Authorization: Bearer <token>]
@@ -152,10 +156,10 @@ For simplicity, the policy always returns `true`.
 
 #### Request payload
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "<subject_from_jwt>"
   },
   "action": {
@@ -173,12 +177,14 @@ For simplicity, the policy always returns `true`.
 > Note:
 > Each of the `subject`, `action`, `resource` fields MAY contain additional key/value pairs in the `properties` field - for example, additional information about the subject or resource. In addition, the `context` field MAY contain additional key/value pairs - for example, HTTP headers for the request. 
 > HTTP Gateways that map these into standard locations as per the [AuthZEN REST API Gateway Profile proposal](https://hackmd.io/MTJPf_vzSmubctNtHis99g) are compliant with these payloads. The PDPs, however, will ignore those extra fields for the purpose of this interop showcase.
+> Feb 22 2025: changed `subject.type` from "user" to "identity"
+
 
 #### Response payload
 
 For every subject and resource combination:
 
-```json=
+```js
 {
   "decision": true
 }
@@ -194,10 +200,10 @@ For simplicity, the policy always returns `true` for every user.
 
 ##### Evaluation API Request payload
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "<subject_from_jwt>"
   },
   "action": {
@@ -215,12 +221,13 @@ For simplicity, the policy always returns `true` for every user.
 > Note:
 > Each of the `subject`, `action`, `resource` fields MAY contain additional key/value pairs in the `properties` field - for example, additional information about the subject or resource. In addition, the `context` field MAY contain additional key/value pairs - for example, HTTP headers for the request. 
 > HTTP Gateways that map these into standard locations as per the [AuthZEN REST API Gateway Profile proposal](https://hackmd.io/MTJPf_vzSmubctNtHis99g) are compliant with these payloads. The PDPs, however, will ignore those extra fields for the purpose of this interop showcase.
+> Feb 22 2025: changed `subject.type` from "user" to "identity"
 
 ##### Evaluation API Response payload
 
 For every subject and resource combination:
 
-```json=
+```js
 {
   "decision": true
 }
@@ -234,10 +241,10 @@ The policy evaluates the subject's `roles` attribute to determine whether the us
 
 #### Request payload
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "<subject_from_jwt>"
   },
   "action": {
@@ -255,12 +262,13 @@ The policy evaluates the subject's `roles` attribute to determine whether the us
 > Note:
 > Each of the `subject`, `action`, `resource` fields MAY contain additional key/value pairs in the `properties` field - for example, additional information about the subject or resource. In addition, the `context` field MAY contain additional key/value pairs - for example, HTTP headers for the request. 
 > HTTP Gateways that map these into standard locations as per the [AuthZEN REST API Gateway Profile proposal](https://hackmd.io/MTJPf_vzSmubctNtHis99g) are compliant with these payloads. The PDPs, however, will ignore those extra fields for the purpose of this interop showcase.
+> Feb 22 2025: changed `subject.type` from "user" to "identity"
 
 #### Response payload
 
 Only users with a `roles` attribute that contains `admin` or `editor` return a `true` decision. In the user set above, this includes Rick, Morty, and Summer.
 
-```json=
+```js
 {
   "decision": true
 }
@@ -268,7 +276,7 @@ Only users with a `roles` attribute that contains `admin` or `editor` return a `
 
 For the other two users, Beth and Jerry, the decision is `false`.
 
-```json=
+```js
 {
   "decision": false
 }
@@ -286,10 +294,10 @@ However, given the fact that the incoming HTTP request DOES NOT include informat
 
 #### Request payload
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "<subject_from_jwt>"
   },
   "action": {
@@ -307,6 +315,7 @@ However, given the fact that the incoming HTTP request DOES NOT include informat
 > Note:
 > Each of the `subject`, `action`, `resource` fields MAY contain additional key/value pairs in the `properties` field - for example, additional information about the subject or resource. In addition, the `context` field MAY contain additional key/value pairs - for example, HTTP headers for the request. 
 > HTTP Gateways that map these into standard locations as per the [AuthZEN REST API Gateway Profile proposal](https://hackmd.io/MTJPf_vzSmubctNtHis99g) are compliant with these payloads. The PDPs, however, will ignore those extra fields for the purpose of this interop showcase.
+> Feb 22 2025: changed `subject.type` from "user" to "identity"
 
 #### Response payload
 
@@ -314,10 +323,10 @@ Only users with a `roles` attribute that contains `evil_genius` (Rick), OR `edit
 
 For the user Morty, the following request will return a `true` decision:
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -332,7 +341,7 @@ For the user Morty, the following request will return a `true` decision:
 }
 ```
 
-```json=
+```js
 {
   "decision": true
 }
@@ -340,12 +349,11 @@ For the user Morty, the following request will return a `true` decision:
 
 For Jerry (who is a `viewer`), the decision will be `false`:
 
-```json=
+```js
 {
   "decision": false
 }
 ```
-
 
 ### `DELETE /todos/{todoId}`
 
@@ -359,10 +367,10 @@ However, given the fact that the incoming HTTP request DOES NOT include informat
 
 #### Request payload
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "<subject_from_jwt>"
   },
   "action": {
@@ -380,6 +388,7 @@ However, given the fact that the incoming HTTP request DOES NOT include informat
 > Note:
 > Each of the `subject`, `action`, `resource` fields MAY contain additional key/value pairs in the `properties` field - for example, additional information about the subject or resource. In addition, the `context` field MAY contain additional key/value pairs - for example, HTTP headers for the request. 
 > HTTP Gateways that map these into standard locations as per the [AuthZEN REST API Gateway Profile proposal](https://hackmd.io/MTJPf_vzSmubctNtHis99g) are compliant with these payloads. The PDPs, however, will ignore those extra fields for the purpose of this interop showcase.
+> Feb 22 2025: changed `subject.type` from "user" to "identity"
 
 #### Response payload
 
@@ -387,10 +396,10 @@ Only users with a `roles` attribute that contains `admin` (Rick), OR `editor` (M
 
 For the user Morty, the following request will return a `true` decision:
 
-```json=
+```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -405,7 +414,7 @@ For the user Morty, the following request will return a `true` decision:
 }
 ```
 
-```json=
+```js
 {
   "decision": true
 }
@@ -413,7 +422,7 @@ For the user Morty, the following request will return a `true` decision:
 
 For Jerry (who is a `viewer`), the decision will be `false`:
 
-```json=
+```js
 {
   "decision": false
 }

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/RockSolidKnowledge.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/RockSolidKnowledge.md
@@ -25,7 +25,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -47,7 +47,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -69,7 +69,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -91,7 +91,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -113,7 +113,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -135,7 +135,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -157,7 +157,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -179,7 +179,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -201,7 +201,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -223,7 +223,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -245,7 +245,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -267,7 +267,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -289,7 +289,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -311,7 +311,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -333,7 +333,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -355,7 +355,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -377,7 +377,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -399,7 +399,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -421,7 +421,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -443,7 +443,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -465,7 +465,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -487,7 +487,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -509,7 +509,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -531,7 +531,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -553,7 +553,7 @@ $ node build/runner.js https://authzen.identityserver.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/aserto.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/aserto.md
@@ -27,7 +27,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -49,7 +49,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -71,7 +71,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -93,7 +93,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -115,7 +115,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -137,7 +137,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -159,7 +159,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -181,7 +181,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -203,7 +203,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -225,7 +225,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -247,7 +247,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -269,7 +269,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -291,7 +291,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -313,7 +313,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -335,7 +335,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -357,7 +357,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -379,7 +379,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -401,7 +401,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -423,7 +423,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -445,7 +445,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -467,7 +467,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -489,7 +489,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -511,7 +511,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -533,7 +533,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -555,7 +555,7 @@ $ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/axiomatics.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/axiomatics.md
@@ -25,7 +25,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -47,7 +47,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -69,7 +69,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -91,7 +91,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -113,7 +113,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -135,7 +135,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -157,7 +157,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -179,7 +179,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -201,7 +201,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -223,7 +223,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -245,7 +245,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -267,7 +267,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -289,7 +289,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -311,7 +311,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -333,7 +333,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -355,7 +355,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -377,7 +377,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -399,7 +399,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -421,7 +421,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -443,7 +443,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -465,7 +465,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -487,7 +487,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -509,7 +509,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -531,7 +531,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -553,7 +553,7 @@ $ node build/runner.js https://pdp.alfa.guide markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/cerbos.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/cerbos.md
@@ -25,7 +25,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -47,7 +47,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -69,7 +69,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -91,7 +91,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -113,7 +113,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -135,7 +135,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -157,7 +157,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -179,7 +179,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -201,7 +201,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -223,7 +223,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -245,7 +245,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -267,7 +267,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -289,7 +289,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -311,7 +311,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -333,7 +333,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -355,7 +355,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -377,7 +377,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -399,7 +399,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -421,7 +421,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -443,7 +443,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -465,7 +465,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -487,7 +487,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -509,7 +509,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -531,7 +531,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -553,7 +553,7 @@ $ node build/runner.js https://authzen-proxy-demo.cerbos.dev markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/plainid.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/plainid.md
@@ -25,7 +25,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -47,7 +47,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -69,7 +69,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -91,7 +91,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -113,7 +113,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -135,7 +135,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -157,7 +157,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -179,7 +179,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -201,7 +201,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -223,7 +223,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -245,7 +245,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -267,7 +267,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -289,7 +289,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -311,7 +311,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -333,7 +333,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -355,7 +355,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -377,7 +377,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -399,7 +399,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -421,7 +421,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -443,7 +443,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -465,7 +465,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -487,7 +487,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -509,7 +509,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -531,7 +531,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {
@@ -553,7 +553,7 @@ $ node build/runner.js https://authzeninteropt.se-plainid.com markdown
 ```js
 {
   "subject": {
-    "type": "user",
+    "type": "identity",
     "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
   },
   "action": {


### PR DESCRIPTION
This PR changes a number of artifacts to use "identity" instead of "user" for `subject.type` 

This is based on feedback that the strings we use are PIDs from JWTs, and do not resemble what a "user" id would look like (typically an email).
