### PR TITLE
envoy: Support PDP AuthN

### DIFF
--- a/interop/authzen-api-gateways/envoy-gateway/authzen-external-authorizer/authzen.go
+++ b/interop/authzen-api-gateways/envoy-gateway/authzen-external-authorizer/authzen.go
@@ -3,12 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -24,29 +22,6 @@ var pdps = map[string]string{
 	"PlainID":              "https://authzeninteropt.se-plainid.com",
 	"Rock Solid Knowledge": "https://authzen.identityserver.com",
 	"Topaz":                "https://authzen-topaz.demo.aserto.com",
-}
-
-// PDPAuthConfig stores authentication configuration for PDPs
-type PDPAuthConfig struct {
-	Token string `json:"token"`
-}
-
-var pdpAuthConfigs map[string]PDPAuthConfig
-
-func init() {
-	// Initialize PDP auth configurations from environment variable
-	if authConfigB64 := os.Getenv("AUTHZEN_PDP_AUTH_CONFIG"); authConfigB64 != "" {
-		authConfigJSON, err := base64.StdEncoding.DecodeString(authConfigB64)
-		if err != nil {
-			log.Printf("Warning: Failed to decode PDP auth config: %v", err)
-			return
-		}
-
-		if err := json.Unmarshal(authConfigJSON, &pdpAuthConfigs); err != nil {
-			log.Printf("Warning: Failed to parse PDP auth config: %v", err)
-			return
-		}
-	}
 }
 
 // AuthZENSubject represents the subject in the authorization request
@@ -142,6 +117,7 @@ func (server *AuthServer) AuthorizeRequest(ctx context.Context, request *auth_pb
 		log.Printf("Failed to encode payload: %v\n", err)
 		return false, err
 	}
+	log.Printf("PDP: %+v\n", pdpUrl)
 	log.Printf("Payload: %+v\n", authZENPayload)
 
 	// Create HTTP request with context
@@ -153,8 +129,9 @@ func (server *AuthServer) AuthorizeRequest(ctx context.Context, request *auth_pb
 	req.Header.Set("Content-Type", "application/json")
 
 	// Add authentication token if configured for this PDP
-	if pdpAuthConfigs != nil {
-		if authConfig, exists := pdpAuthConfigs[request.Attributes.Request.Http.Headers["x_authzen_gateway_pdp"]]; exists {
+	if server.pdpAuthConfigs != nil {
+		if authConfig, exists := server.pdpAuthConfigs[request.Attributes.Request.Http.Headers["x_authzen_gateway_pdp"]]; exists {
+			log.Printf("Adding authorization header to PDP request")
 			req.Header.Set("Authorization", authConfig.Token)
 		}
 	}


### PR DESCRIPTION
Read keys from env and include in call to PDP

The env variable on the deployment can be constructed via:
```
AUTHZEN_PDP_AUTH_CONFIG=$(echo '{"topaz":{"token":"topaz-token"}}' | base64)
```