### PR TITLE
Fix Misalignment Between Request Payload and Description in PUT Todo Section

### DIFF
--- a/interop/authzen-interop-website/docs/scenarios/todo-1.1/index.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.1/index.md
@@ -361,9 +361,12 @@ The `resource.properties` contains an attribute called `ownerID` which contains 
     "name": "can_update_todo"
   },
   "resource": {
-    "ownerID": "<email_of_owner>",
-    "type": "todo"
-  },
+      "type": "todo",
+      "id": "<uuid-of-the-todo>",
+      "properties": {
+        "ownerID": "<email_of_owner>"
+      }
+    },
   "context": {
   }
 }
@@ -389,8 +392,11 @@ For the user Morty, the following request will return a `true` decision:
     "name": "can_update_todo"
   },
   "resource": {
-    "ownerID": "morty@the-citadel.com",
-    "type": "todo"
+    "type": "todo",
+    "id": "7240d0db-8ff0-41ec-98b2-34a096273b9f",
+    "properties": {
+      "ownerID": "morty@the-citadel.com"
+    }
   },
   "context": {
   }


### PR DESCRIPTION
I'm developing the **PDP evaluation endpoint** for **WSO2 Identity Server**, using the specification while also validating it against **Interop Scenarios**.

I noticed an inconsistency in the **[PUT todo section](https://authzen-interop.net/docs/scenarios/todo-1.1/#put-todosid)**—the descriptions do not align with the corresponding request and response payloads.

For example, the request payload description states:
> *The `resource.properties` contains an attribute called `ownerID`, which holds the owner's ID (as defined in the "Attributes" section above, where it is the owner's email address).*

However, the actual payload **does not contain a `properties` section**, making the description misleading.

To ensure accuracy and consistency, I am submitting this **PR to correct the documentation**.