### PR TITLE
Fix missing userId path parameter in /users/{userId} endpoint

### DIFF
--- a/interop/authzen-api-gateways/aws-api-gateway/openapi/todo-openapi.json
+++ b/interop/authzen-api-gateways/aws-api-gateway/openapi/todo-openapi.json
@@ -230,6 +230,17 @@
         "summary": "Get user",
         "description": "Gets information about a user.",
         "operationId": "b61c0cd1-b380-4440-a430-840ea85f3e9f",
+        "parameters": [
+          {
+              "name": "userId",
+              "in": "path",
+              "description": "ID of the user to retrieve.",
+              "required": true,
+              "schema": {
+              "type": "string"
+              }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Properties of a user",

--- a/interop/authzen-api-gateways/aws-api-gateway/openapi/todo-openapi.json
+++ b/interop/authzen-api-gateways/aws-api-gateway/openapi/todo-openapi.json
@@ -232,13 +232,13 @@
         "operationId": "b61c0cd1-b380-4440-a430-840ea85f3e9f",
         "parameters": [
           {
-              "name": "userId",
-              "in": "path",
-              "description": "ID of the user to retrieve.",
-              "required": true,
-              "schema": {
+            "name": "userId",
+            "in": "path",
+            "description": "ID of the user to retrieve.",
+            "required": true,
+            "schema": {
               "type": "string"
-              }
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR addresses the issue of the missing `userId` path parameter in the `/users/{userId}` endpoint.

Changes:

- Defined userId as a required path parameter in the get operation.
- Set userId type to string to align with the UserObject schema.