### PR TITLE
Fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository contains the output of the [OpenID AuthZEN](https://openid.net/w
 
 ## API spec
 
-The AuthZEN authorization API is versioned in markdown at `api/authzorization-api-1_0.md`. A GitHub workflow builds this into HTML. See the "Building the spec" section for more details.
+The AuthZEN authorization API is versioned in markdown at `api/authorization-api-1_0.md`. A GitHub workflow builds this into HTML. See the "Building the spec" section for more details.
 
 ## Interop harness
 

--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -557,7 +557,7 @@ The `evaluations` request payload includes an OPTIONAL `options` key, with a JSO
 
 This provides a general-purpose mechanism for providing caller-supplied metadata on how the request is to be executed.
 
-One such option conrtols *evaluation semantics*, and is described in {{evaluations-semantics}}.
+One such option controls *evaluation semantics*, and is described in {{evaluations-semantics}}.
 
 A non-normative example of the `options` field is shown below:
 
@@ -634,13 +634,13 @@ Response:
 {
   "evaluations": [
     {
-      decision: true
+      "decision": true
     },
     {
-      decision: false
+      "decision": false
     },
     {
-      decision: true
+      "decision": true
     }
   ]
 }
@@ -689,10 +689,10 @@ Response:
 {
   "evaluations": [
     {
-      decision: true
+      "decision": true
     },
     {
-      decision: false,
+      "decision": false,
       context: {
         "id": "200",
         "reason": "deny_on_first_deny"
@@ -745,7 +745,7 @@ Response:
 {
   "evaluations": [
     {
-      decision: true
+      "decision": true
     }
   ]
 }
@@ -859,7 +859,7 @@ The following payload defines a request for the subjects of type `user` that can
     "type": "user"
   },
   "action": {
-    "name": "can_read",
+    "name": "can_read"
   },
   "resource": {
     "type": "account",
@@ -926,7 +926,7 @@ To retrieve the next page, provide `page.next_token` in the next request:
     "type": "user"
   },
   "action": {
-    "name": "can_read",
+    "name": "can_read"
   },
   "resource": {
     "type": "account",
@@ -985,7 +985,7 @@ The following payload defines a request for the resources of type `account` on w
     "id": "alice@acmecorp.com"
   },
   "action": {
-    "name": "can_read",
+    "name": "can_read"
   },
   "resource": {
     "type": "account"
@@ -1049,7 +1049,7 @@ To retrieve the next page, provide `page.next_token` in the next request:
     "id": "alice@acmecorp.com"
   },
   "action": {
-    "name": "can_read",
+    "name": "can_read"
   },
   "resource": {
     "type": "account"
@@ -1203,7 +1203,7 @@ X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
   },
   "resource": {
     "type": "todo",
-    "id": "1",
+    "id": "1"
   },
   "action": {
     "name": "can_read"
@@ -1335,7 +1335,7 @@ X-Request-ID: bfe9eb29-ab87-4ca3-be83-a1d5d8305716
   },
   "resource": {
     "type": "account",
-    "id": "123",
+    "id": "123"
   }
 }
 ~~~


### PR DESCRIPTION
This PR fix minor typo in  ReadMe and the Spec, that I found when implementing search API in WSO2 Identity Server.

- **Typo Fix**: Corrected the word `"conrtols"` to `"controls"` in the *Evaluations options* section.
- **JSON Fixes**: Fixed several JSON examples by:
  - Quoting unquoted keys such as `decision`
  - Removing trailing commas from objects (e.g., `"id": "123",` → `"id": "123"`)

These changes help improve readability and prevent JSON parsing issues.

@ogazitt please approve if its applicable