### PR TITLE
changed "robotic" to "machine" to describe machine identities

### DIFF
--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -96,7 +96,7 @@ This document describes the API version 1.0. Any updates to this API through sub
 The information model for requests and responses include the following entities: Subject, Action, Resource, Context, and Decision. These are all defined below.
 
 ## Subject {#subject}
-A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.
+A Subject is the user or machine principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.
 
 A Subject is a JSON ({{RFC8259}}) object that contains two REQUIRED keys, `type` and `id`, which have a value typed `string`, and an OPTIONAL key, `properties`, with a value of a JSON object.
 
@@ -1557,7 +1557,7 @@ The PDP SHOULD apply reasonable protections to avoid common attacks tied to requ
 
 # Terminology
 Subject:
-: The user or robotic principal about whom the Authorization API call is being made.
+: The user or machine principal about whom the Authorization API call is being made.
 
 Resource:
 : The target of the request; the resource about which the Authorization API is being made.

--- a/api/schemas/evaluation-request.schema.json
+++ b/api/schemas/evaluation-request.schema.json
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "subject": {
-      "description": "A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.",
+      "description": "A Subject is the user or machine principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.",
       "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-subject",
       "type": "object",
       "required": [
@@ -79,7 +79,7 @@
       }
     },
     "action": {
-      "description": "A Subject is the user or robotic principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.",
+      "description": "A Subject is the user or machine principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.",
       "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-action",
       "type": "object",
       "required": [


### PR DESCRIPTION
This addresses https://github.com/openid/authzen/issues/42 (which I think is reasonable feedback). The term "machine identity" is more prevalent than "robotic identity".
