### PR TITLE
Interop/migrate backend urls

### DIFF
--- a/interop/authzen-api-gateways/aws-api-gateway/openapi/aws-gateway-openapi.json
+++ b/interop/authzen-api-gateways/aws-api-gateway/openapi/aws-gateway-openapi.json
@@ -32,7 +32,7 @@
           "payloadFormatVersion" : "1.0",
           "type" : "http_proxy",
           "httpMethod" : "ANY",
-          "uri" : "https://authzen-todo-backend.demo.aserto.com/{todoId}",
+          "uri" : "https://todo-backend.authzen-interop.net/{todoId}",
           "connectionType" : "INTERNET"
         }
       },
@@ -50,7 +50,7 @@
           "payloadFormatVersion" : "1.0",
           "type" : "http_proxy",
           "httpMethod" : "ANY",
-          "uri" : "https://authzen-todo-backend.demo.aserto.com/{todoId}",
+          "uri" : "https://todo-backend.authzen-interop.net/{todoId}",
           "connectionType" : "INTERNET"
         }
       },
@@ -79,7 +79,7 @@
           "payloadFormatVersion" : "1.0",
           "type" : "http_proxy",
           "httpMethod" : "ANY",
-          "uri" : "https://authzen-todo-backend.demo.aserto.com/todos",
+          "uri" : "https://todo-backend.authzen-interop.net/todos",
           "connectionType" : "INTERNET",
           "timeoutInMillis" : 30000
         }
@@ -98,7 +98,7 @@
           "payloadFormatVersion" : "1.0",
           "type" : "http_proxy",
           "httpMethod" : "ANY",
-          "uri" : "https://authzen-todo-backend.demo.aserto.com/todos",
+          "uri" : "https://todo-backend.authzen-interop.net/todos",
           "connectionType" : "INTERNET",
           "timeoutInMillis" : 30000
         }
@@ -119,7 +119,7 @@
           "payloadFormatVersion" : "1.0",
           "type" : "http_proxy",
           "httpMethod" : "ANY",
-          "uri" : "https://authzen-todo-backend.demo.aserto.com/users",
+          "uri" : "https://todo-backend.authzen-interop.net/users",
           "connectionType" : "INTERNET"
         }
       },

--- a/interop/authzen-api-gateways/aws-api-gateway/pdps.json
+++ b/interop/authzen-api-gateways/aws-api-gateway/pdps.json
@@ -1,5 +1,5 @@
 {
-  "Aserto": "https://authzen-gateway-proxy.demo.aserto.com",
+  "Aserto": "https://topaz-gateway.demo.authzen-interop.net",
   "AVP": "https://authzen-avp.interop-it.org",
   "Axiomatics": "https://pdp.alfa.guide",
   "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
@@ -9,6 +9,6 @@
   "PlainID": "https://authzeninteropt.se-plainid.com",
   "Rock Solid Knowledge": "https://authzen.identityserver.com",
   "SGNL": "https://authzen.sgnlapis.cloud",
-  "Topaz": "https://authzen-topaz.demo.aserto.com",
+  "Topaz": "https://topaz-gateway.demo.authzen-interop.net",
   "WSO2": "https://authzen-interop-demo.wso2.com/api/identity"
 }

--- a/interop/authzen-api-gateways/envoy-gateway/README.md
+++ b/interop/authzen-api-gateways/envoy-gateway/README.md
@@ -8,4 +8,4 @@ docker compose up
 
 Then the todo application backend will be avaliable on `localhost:9000` with all requests being authorized by the configured PDP.
 
-Make sure configure the frontend app to use this endpoint rather than `authzen-todo-backend.demo.aserto.com` directly as the Envoy proxy is configured to forward on the request if it is allowed.
+Make sure configure the frontend app to use this endpoint rather than `todo-backend.authzen-interop.net` directly as the Envoy proxy is configured to forward on the request if it is allowed.

--- a/interop/authzen-api-gateways/envoy-gateway/authzen-external-authorizer/authzen.go
+++ b/interop/authzen-api-gateways/envoy-gateway/authzen-external-authorizer/authzen.go
@@ -16,7 +16,7 @@ import (
 
 // PDP URLs
 var pdps = map[string]string{
-	"Aserto":               "https://authzen-gateway-proxy.demo.aserto.com",
+	"Aserto":               "https://topaz-gateway.demo.authzen-interop.net",
 	"AVP":                  "https://authzen-avp.interop-it.org",
 	"Axiomatics":           "https://pdp.alfa.guide",
 	"Cerbos":               "https://authzen-proxy-demo.cerbos.dev",
@@ -26,7 +26,7 @@ var pdps = map[string]string{
 	"PlainID":              "https://authzeninteropt.se-plainid.com",
 	"Rock Solid Knowledge": "https://authzen.identityserver.com",
 	"SGNL":                 "https://authzen.sgnlapis.cloud",
-	"Topaz":                "https://authzen-topaz.demo.aserto.com",
+	"Topaz":                "https://topaz-gateway.demo.authzen-interop.net",
 	"WSO2":                 "https://authzen-interop-demo.wso2.com/api/identity",
 }
 

--- a/interop/authzen-api-gateways/envoy-gateway/envoy/envoy.yaml
+++ b/interop/authzen-api-gateways/envoy-gateway/envoy/envoy.yaml
@@ -36,7 +36,7 @@ static_resources:
                           route:
                             cluster: backend_cluster
                             timeout: 10s
-                            host_rewrite_literal: authzen-todo-backend.demo.aserto.com
+                            host_rewrite_literal: todo-backend.authzen-interop.net
                 http_filters:
                   - name: envoy.filters.http.ext_authz
                     typed_config:
@@ -86,7 +86,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: authzen-todo-backend.demo.aserto.com
+                      address: todo-backend.authzen-interop.net
                       port_value: 443
       transport_socket:
         name: envoy.transport_sockets.tls

--- a/interop/authzen-api-gateways/kong-gateway/conf.yaml
+++ b/interop/authzen-api-gateways/kong-gateway/conf.yaml
@@ -1,7 +1,7 @@
 _transform: false
 _format_version: '3.0'
 services:
-- host: authzen-todo-backend.demo.aserto.com
+- host: todo-backend.authzen-interop.net
   port: 443
   name: AuthZEN_Interop
   retries: 5
@@ -40,7 +40,7 @@ plugins:
   route: 51799165-1a03-495c-b390-4ac7e7047061
   config:
     server:
-      pdp_url: '{     "Aserto":"https://authzen-gateway-proxy.demo.aserto.com",    "AVP": "https://authzen-avp.interop-it.org",    "Axiomatics": "https://pdp.alfa.guide",   "Cerbos":"https://authzen-proxy-demo.cerbos.dev",     "OpenFGA": "https://authzen-interop.openfga.dev/stores/01JNW1803442023HVDKV03FB3A",     "PlainID":"https://authzeninteropt.se-plainid.com",     "Rock Solid Knowledge": "https://authzen.identityserver.com",     "Topaz": "https://authzen-topaz.demo.aserto.com",     "SGNL": "https://authzen.sgnlapis.cloud",       "WSO2": "https://authzen-interop-demo.wso2.com/api/identity" }'
+      pdp_url: '{     "Aserto":"https://topaz-gateway.demo.authzen-interop.net",    "AVP": "https://authzen-avp.interop-it.org",    "Axiomatics": "https://pdp.alfa.guide",   "Cerbos":"https://authzen-proxy-demo.cerbos.dev",     "OpenFGA": "https://authzen-interop.openfga.dev/stores/01JNW1803442023HVDKV03FB3A",     "PlainID":"https://authzeninteropt.se-plainid.com",     "Rock Solid Knowledge": "https://authzen.identityserver.com",     "Topaz": "https://topaz-gateway.demo.authzen-interop.net",     "SGNL": "https://authzen.sgnlapis.cloud",       "WSO2": "https://authzen-interop-demo.wso2.com/api/identity" }'
   protocols:
   - grpc
   - grpcs
@@ -59,7 +59,7 @@ plugins:
   config:
     origins:
       - http://localhost:3000
-      - https://citadel.demo.aserto.com
+      - https://citadel.authzen-interop.net
       - https://todo.authzen-interop.net
     credentials: false
     preflight_continue: false

--- a/interop/authzen-api-gateways/test-harness/test/runner.ts
+++ b/interop/authzen-api-gateways/test-harness/test/runner.ts
@@ -2,7 +2,7 @@ import clc from "cli-color";
 import { evaluation } from "./decisions.json";
 
 const AUTHZEN_PDP_URL =
-  process.argv[2] || "https://authzen-gateway-proxy.demo.aserto.com";
+  process.argv[2] || "https://topaz-gateway.demo.authzen-interop.net";
 const AUTHZEN_PDP_API_KEY = process.env.AUTHZEN_PDP_API_KEY;
 
 enum OutputTypes {

--- a/interop/authzen-api-gateways/tyk-gateway/authzen.apidefinition.yaml
+++ b/interop/authzen-api-gateways/tyk-gateway/authzen.apidefinition.yaml
@@ -95,4 +95,4 @@ x-tyk-api-gateway:
       strip: true
       value: /
   upstream:
-    url: https://authzen-todo-backend.demo.aserto.com
+    url: https://todo-backend.authzen-interop.net

--- a/interop/authzen-api-gateways/tyk-gateway/plugins/authzen.go
+++ b/interop/authzen-api-gateways/tyk-gateway/plugins/authzen.go
@@ -24,7 +24,7 @@ type PDPCredentials map[string]string
 var (
 	logger = log.Get()
 	pdps   = map[string]string{
-		"Aserto":               "https://authzen-gateway-proxy.demo.aserto.com",
+		"Aserto":               "https://topaz-gateway.demo.authzen-interop.net",
 		"AVP":                  "https://authzen-avp.interop-it.org",
 		"Axiomatics":           "https://pdp.alfa.guide",
 		"Cerbos":               "https://authzen-proxy-demo.cerbos.dev",
@@ -34,7 +34,7 @@ var (
 		"PlainID":              "https://authzeninteropt.se-plainid.com",
 		"Rock Solid Knowledge": "https://authzen.identityserver.com",
 		"SGNL":                 "https://authzen.sgnlapis.cloud",
-		"Topaz":                "https://authzen-topaz.demo.aserto.com",
+		"Topaz":                "https://topaz-gateway.demo.authzen-interop.net",
 		"WSO2":                 "https://authzen-interop-demo.wso2.com/api/identity",
 	}
 	creds PDPCredentials

--- a/interop/authzen-api-gateways/zuplo-gateway/config/policies.json
+++ b/interop/authzen-api-gateways/zuplo-gateway/config/policies.json
@@ -18,8 +18,8 @@
         "module": "$import(@zuplo/runtime)",
         "options": {
           "audience": "citadel-app",
-          "issuer": "https://citadel.demo.aserto.com/dex",
-          "jwkUrl": "https://citadel.demo.aserto.com/dex/keys"
+          "issuer": "https://citadel.authzen-interop.net/dex",
+          "jwkUrl": "https://citadel.authzen-interop.net/dex/keys"
         }
       },
       "name": "open-id-jwt-auth-inbound",

--- a/interop/authzen-api-gateways/zuplo-gateway/config/routes.oas.json
+++ b/interop/authzen-api-gateways/zuplo-gateway/config/routes.oas.json
@@ -290,7 +290,7 @@
             "export": "urlForwardHandler",
             "module": "$import(@zuplo/runtime)",
             "options": {
-              "baseUrl": "https://authzen-todo-backend.demo.aserto.com"
+              "baseUrl": "https://todo-backend.authzen-interop.net"
             }
           },
           "policies": {
@@ -328,7 +328,7 @@
             "export": "urlForwardHandler",
             "module": "$import(@zuplo/runtime)",
             "options": {
-              "baseUrl": "https://authzen-todo-backend.demo.aserto.com"
+              "baseUrl": "https://todo-backend.authzen-interop.net"
             }
           },
           "policies": {
@@ -397,7 +397,7 @@
             "export": "urlForwardHandler",
             "module": "$import(@zuplo/runtime)",
             "options": {
-              "baseUrl": "https://authzen-todo-backend.demo.aserto.com"
+              "baseUrl": "https://todo-backend.authzen-interop.net"
             }
           },
           "policies": {
@@ -461,7 +461,7 @@
             "export": "urlForwardHandler",
             "module": "$import(@zuplo/runtime)",
             "options": {
-              "baseUrl": "https://authzen-todo-backend.demo.aserto.com"
+              "baseUrl": "https://todo-backend.authzen-interop.net"
             }
           },
           "policies": {
@@ -541,7 +541,7 @@
             "export": "urlForwardHandler",
             "module": "$import(@zuplo/runtime)",
             "options": {
-              "baseUrl": "https://authzen-todo-backend.demo.aserto.com"
+              "baseUrl": "https://todo-backend.authzen-interop.net"
             }
           },
           "policies": {

--- a/interop/authzen-api-gateways/zuplo-gateway/modules/authzen-original.ts
+++ b/interop/authzen-api-gateways/zuplo-gateway/modules/authzen-original.ts
@@ -1,7 +1,7 @@
 import { HttpProblems, ZuploContext, ZuploRequest, environment } from "@zuplo/runtime"
 
 const pdps = {
-  "Aserto": "https://authzen-gateway-proxy.demo.aserto.com",
+  "Aserto": "https://topaz-gateway.demo.authzen-interop.net",
   "AVP": "https://authzen-avp.interop-it.org",
   "Axiomatics": "https://pdp.alfa.guide",
   "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
@@ -11,7 +11,7 @@ const pdps = {
   "PlainID": "https://authzeninteropt.se-plainid.com",
   "Rock Solid Knowledge": "https://authzen.identityserver.com",
   "SGNL": "https://authzen.sgnlapis.cloud",
-  "Topaz": "https://authzen-topaz.demo.aserto.com",
+  "Topaz": "https://topaz-gateway.demo.authzen-interop.net",
   "WSO2": "https://authzen-interop-demo.wso2.com/api/identity"
 }
 const { AUTHZEN_PDP_API_KEYS } = environment

--- a/interop/authzen-api-gateways/zuplo-gateway/modules/authzen.ts
+++ b/interop/authzen-api-gateways/zuplo-gateway/modules/authzen.ts
@@ -1,7 +1,7 @@
 import {ZuploContext, ZuploRequest, AuthZenInboundPolicy, HttpProblems, environment} from "@zuplo/runtime";
 
 const pdps = {
-  "Aserto": "https://authzen-gateway-proxy.demo.aserto.com",
+  "Aserto": "https://topaz-gateway.demo.authzen-interop.net",
   "AVP": "https://authzen-avp.interop-it.org",
   "Axiomatics": "https://pdp.alfa.guide",
   "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
@@ -11,7 +11,7 @@ const pdps = {
   "PlainID": "https://authzeninteropt.se-plainid.com",
   "Rock Solid Knowledge": "https://authzen.identityserver.com",
   "SGNL": "https://authzen.sgnlapis.cloud",
-  "Topaz": "https://authzen-topaz.demo.aserto.com",
+  "Topaz": "https://topaz-gateway.demo.authzen-interop.net",
   "WSO2": "https://authzen-interop-demo.wso2.com/api/identity"
 }
 const { AUTHZEN_PDP_API_KEYS } = environment

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/aserto.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/aserto.md
@@ -4,16 +4,16 @@ sidebar_position: 1
 
 # Aserto
 
-Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://authzen-gateway-proxy.demo.aserto.com.
+Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://topaz-gateway.demo.authzen-interop.net.
 
 For more information, please refer to the [code](https://github.com/aserto-dev/authzen-gateway-proxy).
 
 ## Test results
 
 ```bash
-yarn test https://authzen-gateway-proxy.demo.aserto.com markdown
+AUTHZEN_PDP_API_KEY=<basic redacted> yarn test https://topaz-gateway.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/runner.js https://authzen-gateway-proxy.demo.aserto.com markdown
+$ node build/runner.js https://topaz-gateway.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/api-gateway/results/topaz.md
+++ b/interop/authzen-interop-website/docs/scenarios/api-gateway/results/topaz.md
@@ -4,16 +4,16 @@ sidebar_position: 6
 
 # Topaz
 
-Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://authzen-topaz.demo.aserto.com.
+Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://topaz-gateway.demo.authzen-interop.net.
 
 Note that as of Topaz 0.32.52, the AuthZEN APIs are provided natively (no need for a proxy).
 
 ## Test results
 
 ```bash
-AUTHZEN_PDP_API_KEY="basic <redacted>" yarn test https://authzen-topaz.demo.aserto.com markdown
+AUTHZEN_PDP_API_KEY="basic <redacted>" yarn test https://topaz-gateway.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/runner.js https://authzen-topaz.demo.aserto.com markdown
+$ node build/runner.js https://topaz-gateway.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/results/aserto.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/results/aserto.md
@@ -4,16 +4,16 @@ sidebar_position: 1
 
 # Aserto
 
-Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://authzen-proxy.demo.aserto.com.
+Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://topaz-proxy.demo.authzen-interop.net.
 
-For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-proxy.demo.aserto.com), demonstrating the scenario.
+For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://topaz-proxy.demo.authzen-interop.net), demonstrating the scenario.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-proxy.demo.aserto.com markdown
+yarn test https://topaz-proxy.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-proxy.demo.aserto.com markdown
+$ node build/test/runner.js https://topaz-proxy.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/results/opa.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/results/opa.md
@@ -4,14 +4,14 @@ sidebar_position: 3
 
 # Open Policy Agent
 
-Interop results for the [OPA](https://openpolicyagent.org/) implementation hosted at `https://authzen-opa-proxy.demo.aserto.com`.
+Interop results for the [OPA](https://openpolicyagent.org/) implementation hosted at `https://opa-proxy.demo.authzen-interop.net`.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-opa-proxy.demo.aserto.com markdown
+yarn test https://opa-proxy.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-opa-proxy.demo.aserto.com markdown
+$ node build/test/runner.js https://opa-proxy.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/results/topaz.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.0-id/results/topaz.md
@@ -4,16 +4,16 @@ sidebar_position: 4
 
 # Topaz
 
-Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://authzen-topaz-proxy.demo.aserto.com. Note that this implementation deploys a Topaz sidecar in the same pod as the proxy.
+Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://topaz-proxy.demo.authzen-interop.net. Note that this implementation deploys a Topaz sidecar in the same pod as the proxy.
 
-For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-topaz-proxy.demo.aserto.com), demonstrating the scenario.
+For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://topaz-proxy.demo.authzen-interop.net), demonstrating the scenario.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-topaz-proxy.demo.aserto.com markdown
+yarn test https://topaz-proxy.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-topaz-proxy.demo.aserto.com markdown
+$ node build/test/runner.js https://topaz-proxy.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.1/results/aserto.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.1/results/aserto.md
@@ -4,16 +4,16 @@ sidebar_position: 1
 
 # Aserto
 
-Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://authzen-proxy.demo.aserto.com.
+Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://topaz-proxy.demo.authzen-interop.net.
 
-For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-proxy.demo.aserto.com), demonstrating the scenario.
+For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://topaz-proxy.demo.authzen-interop.net), demonstrating the scenario.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-proxy.demo.aserto.com authorization-api-1_0-02  markdown
+yarn test https://topaz-proxy.demo.authzen-interop.net authorization-api-1_0-02  markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-proxy.demo.aserto.com authorization-api-1_0-02  markdown
+$ node build/test/runner.js https://topaz-proxy.demo.authzen-interop.net authorization-api-1_0-02  markdown
 ```
 
 <table>

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.1/results/opa.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.1/results/opa.md
@@ -4,14 +4,14 @@ sidebar_position: 3
 
 # Open Policy Agent
 
-Interop results for the [OPA](https://openpolicyagent.org/) implementation hosted at `https://authzen-opa-proxy.demo.aserto.com`.
+Interop results for the [OPA](https://openpolicyagent.org/) implementation hosted at `https://opa-proxy.demo.authzen-interop.net`.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-opa-proxy.demo.aserto.com authorization-api-1_0-02 markdown
+yarn test https://opa-proxy.demo.authzen-interop.net authorization-api-1_0-02 markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-opa-proxy.demo.aserto.com authorization-api-1_0-02 markdown
+$ node build/test/runner.js https://opa-proxy.demo.authzen-interop.net authorization-api-1_0-02 markdown
 ```
 
 <table>

--- a/interop/authzen-interop-website/docs/scenarios/todo-1.1/results/topaz.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo-1.1/results/topaz.md
@@ -4,16 +4,16 @@ sidebar_position: 4
 
 # Topaz
 
-Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://authzen-topaz-proxy.demo.aserto.com. Note that this implementation deploys a Topaz sidecar in the same pod as the proxy.
+Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://topaz-proxy.demo.authzen-interop.net. Note that this implementation deploys a Topaz sidecar in the same pod as the proxy.
 
-For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-topaz-proxy.demo.aserto.com), demonstrating the scenario.
+For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://topaz-proxy.demo.authzen-interop.net), demonstrating the scenario.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-topaz-proxy.demo.aserto.com  authorization-api-1_0-02 markdown
+yarn test https://topaz-proxy.demo.authzen-interop.net  authorization-api-1_0-02 markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-topaz-proxy.demo.aserto.com authorization-api-1_0-02 markdown
+$ node build/test/runner.js https://topaz-proxy.demo.authzen-interop.net authorization-api-1_0-02 markdown
 ```
 
 <table>

--- a/interop/authzen-interop-website/docs/scenarios/todo/results/aserto.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo/results/aserto.md
@@ -4,16 +4,16 @@ sidebar_position: 1
 
 # Aserto
 
-Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://authzen-proxy-preview.demo.aserto.com.
+Interop results for the [Aserto](https://www.aserto.com/) implementation hosted at https://topaz-proxy.demo.authzen-interop.net.
 
-For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-proxy-preview.demo.aserto.com), demonstrating the scenario.
+For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://topaz-proxy.demo.authzen-interop.net), demonstrating the scenario.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-proxy-preview.demo.aserto.com markdown
+yarn test https://topaz-proxy.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-proxy-preview.demo.aserto.com markdown
+$ node build/test/runner.js https://topaz-proxy.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/todo/results/opa.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo/results/opa.md
@@ -4,14 +4,14 @@ sidebar_position: 8
 
 # Open Policy Agent
 
-Interop results for the [OPA](https://openpolicyagent.org/) implementation hosted at `https://authzen-opa-proxy-preview.demo.aserto.com`.
+Interop results for the [OPA](https://openpolicyagent.org/) implementation hosted at `https://opa-proxy.demo.authzen-interop.net`.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-opa-proxy-preview.demo.aserto.com markdown
+yarn test https://opa-proxy.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-opa-proxy-preview.demo.aserto.com markdown
+$ node build/test/runner.js https://opa-proxy.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-interop-website/docs/scenarios/todo/results/topaz.md
+++ b/interop/authzen-interop-website/docs/scenarios/todo/results/topaz.md
@@ -4,16 +4,16 @@ sidebar_position: 6
 
 # Topaz
 
-Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://authzen-topaz-proxy-preview.demo.aserto.com. Note that this implementation deploys a Topaz sidecar in the same pod as the proxy.
+Interop results for the [Topaz](https://www.topaz.sh/) implementation hosted at https://authzen-topaz-proxy-preview.demo.authzen-interop.net. Note that this implementation deploys a Topaz sidecar in the same pod as the proxy.
 
-For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-topaz-proxy-preview.demo.aserto.com), demonstrating the scenario.
+For more information, please refer to the [code](https://github.com/aserto-dev/authzen-topaz-proxy) and [playground](https://authzen-topaz-proxy-preview.demo.authzen-interop.net), demonstrating the scenario.
 
 ## Test results
 
 ```bash
-yarn test https://authzen-topaz-proxy-preview.demo.aserto.com markdown
+yarn test https://topaz-proxy.demo.authzen-interop.net markdown
 yarn run v1.22.19
-$ node build/test/runner.js https://authzen-topaz-proxy-preview.demo.aserto.com markdown
+$ node build/test/runner.js https://topaz-proxy.demo.authzen-interop.net markdown
 ```
 <table>
   <tr>

--- a/interop/authzen-todo-application/.env
+++ b/interop/authzen-todo-application/.env
@@ -2,4 +2,4 @@ VITE_OIDC_DOMAIN=citadel.authzen-interop.net
 VITE_OIDC_CLIENT_ID=citadel-app
 VITE_OIDC_AUDIENCE=citadel-app
 VITE_API_ORIGIN=https://todo-backend.authzen-interop.net
-# VITE_API_ORIGIN=http://localhost:8080
+VITE_API_ORIGIN=http://localhost:3001

--- a/interop/authzen-todo-application/README.md
+++ b/interop/authzen-todo-application/README.md
@@ -14,9 +14,9 @@ In addition to providing a standard Todo interface based on the [TodoMVC](https:
 
 This sample requires a backend that implements the Todo API.
 
-The [authzen-todo-backend](https://github.com/aserto-dev/authzen-todo-backend) repo contains a Node.JS implementation of the API, which calls an AuthZEN-compliant Policy Decision Point (PDP) to authorize each request. See instructions in that repo for how to build, configure, and run the backend.
+The [authzen-todo-backend](https://github.com/openid/authzen/tree/main/interop/authzen-todo-backend) repo contains a Node.JS implementation of the API, which calls an AuthZEN-compliant Policy Decision Point (PDP) to authorize each request. See instructions in that repo for how to build, configure, and run the backend.
 
-Alternatively, the backend is hosted [here](https://authzen-todo-backend.demo.aserto.com). The `.env` file in this repo set the `REACT_APP_API_ORIGIN` environment variable to this service. If you'd like to point it instead to your own backend, simply change the value of this variable (e.g. `http://localhost:8080`).
+Alternatively, the backend is hosted [here](https://todo-backend.authzen-interop.net). The `.env` file in this repo set the `REACT_APP_API_ORIGIN` environment variable to this service. If you'd like to point it instead to your own backend, simply change the value of this variable (e.g. `http://localhost:8080`).
 
 ## Identities
 

--- a/interop/authzen-todo-backend/.env.example
+++ b/interop/authzen-todo-backend/.env.example
@@ -1,5 +1,5 @@
-JWKS_URI=https://citadel.demo.aserto.com/dex/keys
-ISSUER=https://citadel.demo.aserto.com/dex
+JWKS_URI=https://citadel.authzen-interop.net/dex/keys
+ISSUER=https://citadel.authzen-interop.net/dex
 AUDIENCE=citadel-app
 
-AUTHZEN_PDP_URL=https://authzen-proxy.demo.aserto.com
+AUTHZEN_PDP_URL=https://topaz-proxy.demo.authzen-interop.net

--- a/interop/authzen-todo-backend/.github/workflows/nodejs.yaml
+++ b/interop/authzen-todo-backend/.github/workflows/nodejs.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  AUTHZEN_PDP_URL: https://authzen-proxy.demo.aserto.com
+  AUTHZEN_PDP_URL: https://authzen-proxy.demo.authzen-interop.net
 
 jobs:
   tests:

--- a/interop/authzen-todo-backend/.github/workflows/nodejs.yaml
+++ b/interop/authzen-todo-backend/.github/workflows/nodejs.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  AUTHZEN_PDP_URL: https://authzen-proxy.demo.authzen-interop.net
+  AUTHZEN_PDP_URL: https://topaz-proxy.demo.authzen-interop.net
 
 jobs:
   tests:

--- a/interop/authzen-todo-backend/README.md
+++ b/interop/authzen-todo-backend/README.md
@@ -19,8 +19,8 @@ Optionally, set the `AUTHZEN_PDP_API_KEY` variable if your authorizer needs an A
 Example `.env` file:
 
 ```shell
-JWKS_URI=https://citadel.demo.aserto.com/dex/keys
-ISSUER=https://citadel.demo.aserto.com/dex
+JWKS_URI=https://citadel.authzen-interop.net/dex/keys
+ISSUER=https://citadel.authzen-interop.net/dex
 AUDIENCE=citadel-app
 
 AUTHZEN_PDP_URL=https://authorizer.domain.com

--- a/interop/authzen-todo-backend/src/pdps.json
+++ b/interop/authzen-todo-backend/src/pdps.json
@@ -1,7 +1,7 @@
 {
   "pdps": {
     "authorization-api-1_0-01": {
-      "Aserto": "https://authzen-proxy.demo.aserto.com",
+      "Aserto": "https://topaz-proxy.demo.authzen-interop.net",
       "AVP": "https://authzen-avp.interop-it.org",
       "Axiomatics": "https://pdp.alfa.guide",
       "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
@@ -9,18 +9,18 @@
       "HexaOPA": "https://interop.authzen.hexaorchestration.org",
       "Indykite": "https://api-authzen-authz.3edges.io",
       "Kogito": "https://authzen-proxy-demo.azerad.org",
-      "Open Policy Agent": "https://authzen-opa-proxy.demo.aserto.com",
+      "Open Policy Agent": "https://opa-proxy.demo.authzen-interop.net",
       "OpenFGA": "https://authzen-interop.openfga.dev/stores/01JG9JGS4W0950VN17G8NNAH3C",
       "Permit.io": "https://permit-authzen-interop.up.railway.app",
       "PingAuthorize": "https://authzen.idpartners.au",
       "PlainID": "https://authzeninteropt.se-plainid.com",
       "Rock Solid Knowledge": "https://authzen.identityserver.com",
       "SGNL": "https://authzen.sgnlapis.cloud",
-      "Topaz": "https://authzen-topaz-proxy.demo.aserto.com",
+      "Topaz": "https://topaz-proxy.demo.authzen-interop.net",
       "WSO2": "https://authzen-interop-demo.wso2.com/api/identity"
     },
     "authorization-api-1_0-02": {
-      "Aserto": "https://authzen-proxy.demo.aserto.com",
+      "Aserto": "https://topaz-proxy.demo.authzen-interop.net",
       "AVP": "https://authzen-avp.interop-it.org",
       "Axiomatics": "https://pdp.alfa.guide",
       "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
@@ -28,19 +28,20 @@
       "HexaOPA": "https://interop.authzen.hexaorchestration.org",
       "Indykite": "https://api-authzen-authz.3edges.io",
       "Kogito": "https://authzen-proxy-demo.azerad.org",
-      "Open Policy Agent": "https://authzen-opa-proxy.demo.aserto.com",
+      "Open Policy Agent": "https://opa-proxy.demo.authzen-interop.net",
       "OpenFGA": "https://authzen-interop.openfga.dev/stores/01JG9JGS4W0950VN17G8NNAH3C",
       "Permit.io": "https://permit-authzen-interop.up.railway.app",
       "PingAuthorize": "https://authzen.idpartners.au",
       "PlainID": "https://authzeninteropt.se-plainid.com",
       "Rock Solid Knowledge": "https://authzen.identityserver.com",
       "SGNL": "https://authzen.sgnlapis.cloud",
-      "Topaz": "https://authzen-topaz-proxy.demo.aserto.com",
+      "Topaz": "https://topaz-proxy.demo.authzen-interop.net",
       "WSO2": "https://authzen-interop-demo.wso2.com/api/identity"
     }
   },
   "gateways": {
     "--Pass Through--": "https://todo-backend.authzen-interop.net",
+    "--Local--": "http://localhost:3001",
     "AWS API Gateway": "https://aws-gateway.authzen-interop.net",
     "Envoy": "https://authzen-envoy-proxy-demo.cerbos.dev",
     "Kong": "https://plainid-kong-gw.se-plainid.com",
@@ -50,7 +51,7 @@
     "Zuplo": "https://authzen-todo-main-4df5ceb.d2.zuplo.dev"
   },
   "gatewayPdps": {
-    "Aserto": "http://authzen-gateway-proxy.demo.aserto.com",
+    "Aserto": "http://topaz-gateway.demo.authzen-interop.net",
     "AVP": "https://authzen-avp.interop-it.org",
     "Axiomatics": "https://pdp.alfa.guide",
     "Cerbos": "https://authzen-proxy-demo.cerbos.dev",
@@ -60,7 +61,7 @@
     "PlainID": "https://authzeninteropt.se-plainid.com",
     "Rock Solid Knowledge": "https://authzen.identityserver.com",
     "SGNL": "https://authzen.sgnlapis.cloud",
-    "Topaz": "https://authzen-topaz.demo.aserto.com",
+    "Topaz": "https://topaz-gateway.demo.authzen-interop.net",
     "WSO2": "https://authzen-interop-demo.wso2.com/api/identity"
   }
 }

--- a/interop/authzen-todo-backend/test/runner.ts
+++ b/interop/authzen-todo-backend/test/runner.ts
@@ -2,7 +2,7 @@ import clc from "cli-color";
 import { evaluation } from "./decisions-authorization-api-1_0-01.json";
 
 const AUTHZEN_PDP_URL =
-  process.argv[2] || "https://authzen-proxy.demo.aserto.com";
+  process.argv[2] || "https://topaz-proxy.demo.authzen-interop.net";
 const AUTHZEN_PDP_API_KEY = process.env.AUTHZEN_PDP_API_KEY;
 
 enum OutputTypes {


### PR DESCRIPTION
This PR migrates the authzen-todo-backend.demo.aserto.com to todo-backend.authzen-interop.net.

It also migrates all the Topaz/Aserto PDPs to the topaz-proxy.demo.authzen-interop.net address.

After deploying this build, the gateways will need to update / redeploy the gateway PDPs, and also add a secret for Aserto.

- [x] AWS API Gateway
- [x] Zuplo
- [ ] Envoy
- [ ] Kong
- [ ] Layer7
- [ ] Tyk
- [ ] WSO2