### PR TITLE
create a dummy ./db directory and ignore it in the docker builds

### DIFF
--- a/interop/authzen-todo-backend/.dockerignore
+++ b/interop/authzen-todo-backend/.dockerignore
@@ -18,3 +18,6 @@ README.md
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+todo.db
+.empty


### PR DESCRIPTION
This allows a local `yarn start` to continue to work, since the `./db` directory is part of source control.

The `.dockerignore` will ensure the directory doesn't exist, but will then require a volume mount for the sqllite volume
