### PR TITLE
Add x-coaz-mapping to Figure 2 tools/list example

### DIFF
--- a/profiles/authzen-mcp-profile-1_0.md
+++ b/profiles/authzen-mcp-profile-1_0.md
@@ -293,7 +293,17 @@ both a COAZ-compatible tool and a non-compatible tool:
             "description": "City name or zip code"
           }
         },
-        "required": ["location"]
+        "required": ["location"],
+        "x-coaz-mapping": {
+          "resource": [{
+            "type": "'location'",
+            "id": "params.arguments.location"
+          }],
+          "subject": [{
+            "type": "'user'",
+            "id": "token.sub"
+          }]
+        }
       }
     },
     {


### PR DESCRIPTION
Adds the missing `x-coaz-mapping` field to the `get_weather` tool in the Figure 2 `tools/list` example

Fixes #484
