### PR TITLE
Mark Access Request and Approval Profile as OIDF stream document

### DIFF
--- a/profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.md
+++ b/profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.md
@@ -2,12 +2,14 @@
 title: "AuthZEN Access Request and Approval Profile - Draft 1"
 abbrev: "ARAP"
 category: std
+ipr: none
 
 docname: authzen-access-request-approval-profile-1_0
-submissiontype: IETF
 workgroup: OpenID AuthZEN
 consensus: true
 v: 3
+stand_alone: true
+pi: [toc, sortrefs, symrefs, private]
 keyword:
   - authorization
   - authorization escalation
@@ -20,12 +22,6 @@ keyword:
   - authority
   - step-up authorization
   - governance
-
-venue:
-#  group: "OpenID AuthZEN Working Group"
-#  type: "Working Group"
-#  mail: "openid-specs-authzen@lists.openid.net"
-#  arch: "https://lists.openid.net/pipermail/openid-specs-authzen/"
 
 author:
   -


### PR DESCRIPTION
Follow-up to #508 (merged). The AuthZEN Access Request and Approval Profile is published under the OpenID Foundation, not the IETF, but its front matter still declared `submissiontype: IETF` and carried a `venue` block that made kramdown-rfc emit an "About This Document" note with a hardcoded `datatracker.ietf.org` status link.

This corrects the front matter so the document renders as an OIDF spec:

- Add `ipr: none` and `pi: [toc, sortrefs, symrefs, private]` (the `private` PI suppresses the IETF stream boilerplate: "Status of This Memo" and the Internet-Standards-Track disclaimer).
- Add `stand_alone: true`.
- Remove `submissiontype: IETF` (xml2rfc has no OIDF submissionType; only IETF/IAB/IRTF/independent/editorial are valid).
- Remove the `venue` block, which drops the datatracker "About This Document" note (it cannot be suppressed independently of `venue`).

This matches the sibling `authzen-mcp-profile`, which has no `venue` and renders the same way.

The build-time `submissionType ... found None, will use IETF` warning is expected for OIDF docs in this toolchain (the MCP profile emits it too) and is harmless; the `private` PI governs the rendered output.