### PR TITLE
chore: batch Dependabot updates weekly with majors isolated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,25 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
     groups:
-      actions:
+      actions-minor-and-patch:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: npm
     directories:
       - /interop/**/*
     schedule:
       interval: weekly
+      day: monday
     groups:
       minor-and-patch:
+        patterns: ["*"]
         update-types: ["minor", "patch"]
       major:
+        patterns: ["*"]
         update-types: ["major"]


### PR DESCRIPTION
## What

Tightens `.github/dependabot.yml` so Dependabot opens as few PRs as possible, once a week.

- Pin both `github-actions` and `npm` updates to **Monday** so everything lands the same day.
- Split `github-actions` into `minor-and-patch` and `major` groups (was a single catch-all group).
- Add explicit `patterns: ["*"]` to the `npm` groups.

Majors are kept in their own group so a breaking bump can't block the routine minor/patch PR from merging.

## Result per week

- 1 actions minor/patch PR + (0–1) actions major PR
- Up to 2 PRs per interop npm directory (minor/patch, major)

This is the floor for native Dependabot — it cannot merge updates across different directories into a single PR. Renovate would be required for true single-PR batching.