### PR TITLE
Publish COAZ-MCP binding doc to GitHub Pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -171,6 +171,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: coaz-framework
+      - name: Download artifact - COAZ-MCP binding
+        uses: actions/download-artifact@v8
+        with:
+          name: coaz-mcp-binding
       - name: Download artifact - MCP profile
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
https://openid.github.io/authzen/authzen-coaz-mcp-binding-1_0.html currently 404s.

#541 split COAZ into a framework doc and an MCP binding doc. The `build-rfc` job renders both and uploads a `coaz-mcp-binding` artifact, but the `publish-to-pages` job never downloads that artifact, so the rendered HTML is left out of the Pages deployment.

This adds the missing download step so `authzen-coaz-mcp-binding-1_0.html` gets published alongside the framework doc.