### PR TITLE
Fix broken reference links in superseded MCP profile

### DIFF
--- a/profiles/authzen-mcp-profile-1_0.md
+++ b/profiles/authzen-mcp-profile-1_0.md
@@ -32,11 +32,11 @@ author:
 informative:
   COAZFW:
     title: "COAZ: A Framework for Mapping Information Models to AuthZEN Authorization Requests"
-    target: https://openid.net/specs/authzen-coaz-framework-1_0.html
+    target: https://openid.github.io/authzen/authzen-coaz-framework-1_0.html
     date: 2026
   COAZMCP:
     title: "COAZ-MCP: COAZ Binding for the Model Context Protocol"
-    target: https://openid.net/specs/authzen-coaz-mcp-binding-1_0.html
+    target: https://openid.github.io/authzen/authzen-coaz-mcp-binding-1_0.html
     date: 2026
 
 --- abstract


### PR DESCRIPTION
The superseded MCP profile doc (https://openid.github.io/authzen/authzen-mcp-profile-1_0.html) exists only to point readers at its replacements, but both reference links target `https://openid.net/specs/...` URLs that return 404.

This points the COAZFW and COAZMCP references at the published drafts:

- https://openid.github.io/authzen/authzen-coaz-framework-1_0.html
- https://openid.github.io/authzen/authzen-coaz-mcp-binding-1_0.html

Both verified returning 200.