### PR TITLE
Rework publish pipeline as a build matrix

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -6,10 +6,44 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-rfc:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: authorization-api-1_0
+            source: api/authorization-api-1_0.md
+            html: authorization-api-1_0.html
+            # The working draft of the spec is also published as the site index
+            extra_html: index.html
+          - name: patterns-doc
+            source: patterns/AuthorizationDesignPatterns.md
+            html: patterns.html
+          - name: coaz-framework
+            source: profiles/authzen-coaz-framework-1_0.md
+            html: authzen-coaz-framework-1_0.html
+          - name: coaz-mcp-binding
+            source: profiles/authzen-coaz-mcp-binding-1_0.md
+            html: authzen-coaz-mcp-binding-1_0.html
+          - name: mcp-profile
+            source: profiles/authzen-mcp-profile-1_0.md
+            html: authzen-mcp-profile-1_0.html
+          - name: access-request-approval-profile
+            source: profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.md
+            html: authzen-access-request-approval-profile-1_0.html
+          - name: obligations-profile
+            source: profiles/authzen-obligations-profile-1_0.md
+            html: authzen-obligations-profile-1_0.html
+          - name: certification-scenario
+            source: certification/authorization-api-1_0-scenario.md
+            html: authorization-api-1_0-certification-scenario.html
+    name: build-rfc (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
@@ -19,132 +53,30 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-      - name: Install kramdown-rfc2629
-        run: gem install kramdown-rfc2629
-      - name: Install xml2rfc
-        run: pip install xml2rfc
+      - name: Install kramdown-rfc2629 and xml2rfc
+        run: |
+          gem install kramdown-rfc2629
+          pip install xml2rfc
 
-      - name: Convert working version of Authz API 1.0 to rfc xml
-        run: kramdown-rfc2629 api/authorization-api-1_0.md > api/authorization-api-1_0.xml
-      - name: Render Authz API 1.0 HTML
-        run: xml2rfc api/authorization-api-1_0.xml --html -o authorization-api-1_0.html
-      - name: Render Index HTML (this is the current working draft of the spec)
-        run: xml2rfc api/authorization-api-1_0.xml --html -o index.html
-      - name: Render Authz API 1.0 Text
-        run: xml2rfc api/authorization-api-1_0.xml --text
-      - name: Upload Authz API 1.0 artifact
+      - name: Render ${{ matrix.name }}
+        run: |
+          src='${{ matrix.source }}'
+          xml="${src%.md}.xml"
+          kramdown-rfc2629 "$src" > "$xml"
+          xml2rfc "$xml" --html -o '${{ matrix.html }}'
+          xml2rfc "$xml" --text
+          mkdir -p "dist/$(dirname "$xml")"
+          cp "$xml" "dist/$xml"
+          cp '${{ matrix.html }}' dist/
+          if [ -n '${{ matrix.extra_html }}' ]; then
+            cp '${{ matrix.html }}' 'dist/${{ matrix.extra_html }}'
+          fi
+
+      - name: Upload ${{ matrix.name }} artifact
         uses: actions/upload-artifact@v7
         with:
-          name: authorization-api-1_0
-          path: |
-            index.html
-            authorization-api-1_0.html
-            api/authorization-api-1_0.xml
-
-      - name: Convert Authz Design Patterns to rfc xml
-        run: kramdown-rfc2629 patterns/AuthorizationDesignPatterns.md > patterns/AuthorizationDesignPatterns.xml
-      - name: Render Authz Design Patterns HTML
-        run: xml2rfc patterns/AuthorizationDesignPatterns.xml --html -o patterns.html
-      - name: Render Authz Design Patterns Text
-        run: xml2rfc patterns/AuthorizationDesignPatterns.xml --text
-      - name: Upload Authz Design Patterns artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: patterns-doc
-          path: |
-            patterns.html
-            patterns/AuthorizationDesignPatterns.xml
-
-      - name: Upload Authz API 1.0 original submission artifact (version 0_0)
-        uses: actions/upload-artifact@v7
-        with:
-          name: authorization-api-0_0
-          path: |
-            archive/authorization-api-0_0.html
-
-      - name: Convert COAZ Framework to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-coaz-framework-1_0.md > profiles/authzen-coaz-framework-1_0.xml
-      - name: Render COAZ Framework HTML
-        run: xml2rfc profiles/authzen-coaz-framework-1_0.xml --html -o authzen-coaz-framework-1_0.html
-      - name: Render COAZ Framework Text
-        run: xml2rfc profiles/authzen-coaz-framework-1_0.xml --text
-      - name: Upload COAZ Framework artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coaz-framework
-          path: |
-            authzen-coaz-framework-1_0.html
-            profiles/authzen-coaz-framework-1_0.xml
-
-      - name: Convert COAZ-MCP Binding to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-coaz-mcp-binding-1_0.md > profiles/authzen-coaz-mcp-binding-1_0.xml
-      - name: Render COAZ-MCP Binding HTML
-        run: xml2rfc profiles/authzen-coaz-mcp-binding-1_0.xml --html -o authzen-coaz-mcp-binding-1_0.html
-      - name: Render COAZ-MCP Binding Text
-        run: xml2rfc profiles/authzen-coaz-mcp-binding-1_0.xml --text
-      - name: Upload COAZ-MCP Binding artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coaz-mcp-binding
-          path: |
-            authzen-coaz-mcp-binding-1_0.html
-            profiles/authzen-coaz-mcp-binding-1_0.xml
-
-      - name: Convert MCP Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-mcp-profile-1_0.md > profiles/authzen-mcp-profile-1_0.xml
-      - name: Render MCP Profile HTML
-        run: xml2rfc profiles/authzen-mcp-profile-1_0.xml --html -o authzen-mcp-profile-1_0.html
-      - name: Render MCP Profile Text
-        run: xml2rfc profiles/authzen-mcp-profile-1_0.xml --text
-      - name: Upload MCP Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: mcp-profile
-          path: |
-            authzen-mcp-profile-1_0.html
-            profiles/authzen-mcp-profile-1_0.xml
-
-      - name: Convert Access Request Approval Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.md > profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml
-      - name: Render Access Request Approval Profile HTML
-        run: xml2rfc profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml --html -o authzen-access-request-approval-profile-1_0.html
-      - name: Render Access Request Approval Profile Text
-        run: xml2rfc profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml --text
-      - name: Upload Access Request Approval Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: access-request-approval-profile
-          path: |
-            authzen-access-request-approval-profile-1_0.html
-            profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml
-
-      - name: Convert Obligations Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-obligations-profile-1_0.md > profiles/authzen-obligations-profile-1_0.xml
-      - name: Render Obligations Profile HTML
-        run: xml2rfc profiles/authzen-obligations-profile-1_0.xml --html -o authzen-obligations-profile-1_0.html
-      - name: Render Obligations Profile Text
-        run: xml2rfc profiles/authzen-obligations-profile-1_0.xml --text
-      - name: Upload Obligations Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: obligations-profile
-          path: |
-            authzen-obligations-profile-1_0.html
-            profiles/authzen-obligations-profile-1_0.xml
-
-      - name: Convert Authorization API 1.0 Certification Scenario to rfc xml
-        run: kramdown-rfc2629 certification/authorization-api-1_0-scenario.md > certification/authorization-api-1_0-scenario.xml
-      - name: Render Certification Scenario HTML
-        run: xml2rfc certification/authorization-api-1_0-scenario.xml --html -o authorization-api-1_0-certification-scenario.html
-      - name: Render Certification Scenario Text
-        run: xml2rfc certification/authorization-api-1_0-scenario.xml --text
-      - name: Upload Certification Scenario artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: certification-scenario
-          path: |
-            authorization-api-1_0-certification-scenario.html
-            certification/authorization-api-1_0-scenario.xml
+          name: rfc-${{ matrix.name }}
+          path: dist
 
   publish-to-pages:
     if: github.ref == 'refs/heads/main'
@@ -157,44 +89,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Download artifact
+      - uses: actions/checkout@v7
+      - name: Add archived original submission (version 0_0)
+        run: |
+          mkdir -p site
+          cp archive/authorization-api-0_0.html site/
+      - name: Download rendered documents
         uses: actions/download-artifact@v8
         with:
-          pattern: authorization-api-*
-          path: .
+          pattern: rfc-*
+          path: site
           merge-multiple: true
-      - name: Download artifact - pattern document
-        uses: actions/download-artifact@v8
-        with:
-          name: patterns-doc
-      - name: Download artifact - COAZ framework
-        uses: actions/download-artifact@v8
-        with:
-          name: coaz-framework
-      - name: Download artifact - COAZ-MCP binding
-        uses: actions/download-artifact@v8
-        with:
-          name: coaz-mcp-binding
-      - name: Download artifact - MCP profile
-        uses: actions/download-artifact@v8
-        with:
-          name: mcp-profile
-      - name: Download artifact - Access Request Approval profile
-        uses: actions/download-artifact@v8
-        with:
-          name: access-request-approval-profile
-      - name: Download artifact - Obligations profile
-        uses: actions/download-artifact@v8
-        with:
-          name: obligations-profile
-      - name: Download artifact - Certification Scenario
-        uses: actions/download-artifact@v8
-        with:
-          name: certification-scenario
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: .
+          path: site
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -6,10 +6,53 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-rfc:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: authorization-api-1_0
+            source: api/authorization-api-1_0.md
+            html: authorization-api-1_0.html
+            # The working draft of the spec is also published as the site index
+            extra_html: index.html
+          - name: patterns-doc
+            source: patterns/AuthorizationDesignPatterns.md
+            html: patterns.html
+          - name: coaz-framework
+            source: profiles/authzen-coaz-framework-1_0.md
+            html: authzen-coaz-framework-1_0.html
+          - name: coaz-mcp-binding
+            source: profiles/authzen-coaz-mcp-binding-1_0.md
+            html: authzen-coaz-mcp-binding-1_0.html
+          - name: mcp-profile
+            source: profiles/authzen-mcp-profile-1_0.md
+            html: authzen-mcp-profile-1_0.html
+          - name: access-request-approval-profile
+            source: profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.md
+            html: authzen-access-request-approval-profile-1_0.html
+          - name: obligations-profile
+            source: profiles/authzen-obligations-profile-1_0.md
+            html: authzen-obligations-profile-1_0.html
+          - name: oauth-token-issuance
+            source: profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md
+            html: authzen-oauth-token-issuance-1_0.html
+          - name: oauth-token-exchange
+            source: profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md
+            html: authzen-oauth-token-exchange-1_0.html
+          - name: oauth-authorization-claims
+            source: profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md
+            html: authzen-oauth-authorization-claims-1_0.html
+          - name: certification-scenario
+            source: certification/authorization-api-1_0-scenario.md
+            html: authorization-api-1_0-certification-scenario.html
+    name: build-rfc (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
@@ -19,174 +62,30 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.10"
-      - name: Install kramdown-rfc2629
-        run: gem install kramdown-rfc2629
-      - name: Install xml2rfc
-        run: pip install xml2rfc
+      - name: Install kramdown-rfc2629 and xml2rfc
+        run: |
+          gem install kramdown-rfc2629
+          pip install xml2rfc
 
-      - name: Convert working version of Authz API 1.0 to rfc xml
-        run: kramdown-rfc2629 api/authorization-api-1_0.md > api/authorization-api-1_0.xml
-      - name: Render Authz API 1.0 HTML
-        run: xml2rfc api/authorization-api-1_0.xml --html -o authorization-api-1_0.html
-      - name: Render Index HTML (this is the current working draft of the spec)
-        run: xml2rfc api/authorization-api-1_0.xml --html -o index.html
-      - name: Render Authz API 1.0 Text
-        run: xml2rfc api/authorization-api-1_0.xml --text
-      - name: Upload Authz API 1.0 artifact
+      - name: Render ${{ matrix.name }}
+        run: |
+          src='${{ matrix.source }}'
+          xml="${src%.md}.xml"
+          kramdown-rfc2629 "$src" > "$xml"
+          xml2rfc "$xml" --html -o '${{ matrix.html }}'
+          xml2rfc "$xml" --text
+          mkdir -p "dist/$(dirname "$xml")"
+          cp "$xml" "dist/$xml"
+          cp '${{ matrix.html }}' dist/
+          if [ -n '${{ matrix.extra_html }}' ]; then
+            cp '${{ matrix.html }}' 'dist/${{ matrix.extra_html }}'
+          fi
+
+      - name: Upload ${{ matrix.name }} artifact
         uses: actions/upload-artifact@v7
         with:
-          name: authorization-api-1_0
-          path: |
-            index.html
-            authorization-api-1_0.html
-            api/authorization-api-1_0.xml
-
-      - name: Convert Authz Design Patterns to rfc xml
-        run: kramdown-rfc2629 patterns/AuthorizationDesignPatterns.md > patterns/AuthorizationDesignPatterns.xml
-      - name: Render Authz Design Patterns HTML
-        run: xml2rfc patterns/AuthorizationDesignPatterns.xml --html -o patterns.html
-      - name: Render Authz Design Patterns Text
-        run: xml2rfc patterns/AuthorizationDesignPatterns.xml --text
-      - name: Upload Authz Design Patterns artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: patterns-doc
-          path: |
-            patterns.html
-            patterns/AuthorizationDesignPatterns.xml
-
-      - name: Upload Authz API 1.0 original submission artifact (version 0_0)
-        uses: actions/upload-artifact@v7
-        with:
-          name: authorization-api-0_0
-          path: |
-            archive/authorization-api-0_0.html
-
-      - name: Convert COAZ Framework to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-coaz-framework-1_0.md > profiles/authzen-coaz-framework-1_0.xml
-      - name: Render COAZ Framework HTML
-        run: xml2rfc profiles/authzen-coaz-framework-1_0.xml --html -o authzen-coaz-framework-1_0.html
-      - name: Render COAZ Framework Text
-        run: xml2rfc profiles/authzen-coaz-framework-1_0.xml --text
-      - name: Upload COAZ Framework artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coaz-framework
-          path: |
-            authzen-coaz-framework-1_0.html
-            profiles/authzen-coaz-framework-1_0.xml
-
-      - name: Convert COAZ-MCP Binding to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-coaz-mcp-binding-1_0.md > profiles/authzen-coaz-mcp-binding-1_0.xml
-      - name: Render COAZ-MCP Binding HTML
-        run: xml2rfc profiles/authzen-coaz-mcp-binding-1_0.xml --html -o authzen-coaz-mcp-binding-1_0.html
-      - name: Render COAZ-MCP Binding Text
-        run: xml2rfc profiles/authzen-coaz-mcp-binding-1_0.xml --text
-      - name: Upload COAZ-MCP Binding artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coaz-mcp-binding
-          path: |
-            authzen-coaz-mcp-binding-1_0.html
-            profiles/authzen-coaz-mcp-binding-1_0.xml
-
-      - name: Convert MCP Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-mcp-profile-1_0.md > profiles/authzen-mcp-profile-1_0.xml
-      - name: Render MCP Profile HTML
-        run: xml2rfc profiles/authzen-mcp-profile-1_0.xml --html -o authzen-mcp-profile-1_0.html
-      - name: Render MCP Profile Text
-        run: xml2rfc profiles/authzen-mcp-profile-1_0.xml --text
-      - name: Upload MCP Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: mcp-profile
-          path: |
-            authzen-mcp-profile-1_0.html
-            profiles/authzen-mcp-profile-1_0.xml
-
-      - name: Convert Access Request Approval Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.md > profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml
-      - name: Render Access Request Approval Profile HTML
-        run: xml2rfc profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml --html -o authzen-access-request-approval-profile-1_0.html
-      - name: Render Access Request Approval Profile Text
-        run: xml2rfc profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml --text
-      - name: Upload Access Request Approval Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: access-request-approval-profile
-          path: |
-            authzen-access-request-approval-profile-1_0.html
-            profiles/authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml
-
-      - name: Convert Obligations Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-obligations-profile-1_0.md > profiles/authzen-obligations-profile-1_0.xml
-      - name: Render Obligations Profile HTML
-        run: xml2rfc profiles/authzen-obligations-profile-1_0.xml --html -o authzen-obligations-profile-1_0.html
-      - name: Render Obligations Profile Text
-        run: xml2rfc profiles/authzen-obligations-profile-1_0.xml --text
-      - name: Upload Obligations Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: obligations-profile
-          path: |
-            authzen-obligations-profile-1_0.html
-            profiles/authzen-obligations-profile-1_0.xml
-
-      - name: Convert OAuth 2.0 Token Issuance Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md > profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml
-      - name: Render OAuth 2.0 Token Issuance Profile HTML
-        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml --html -o authzen-oauth-token-issuance-1_0.html
-      - name: Render OAuth 2.0 Token Issuance Profile Text
-        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml --text
-      - name: Upload OAuth 2.0 Token Issuance Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: oauth-token-issuance
-          path: |
-            authzen-oauth-token-issuance-1_0.html
-            profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml
-
-      - name: Convert OAuth 2.0 Token Exchange Binding to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md > profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml
-      - name: Render OAuth 2.0 Token Exchange Binding HTML
-        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml --html -o authzen-oauth-token-exchange-1_0.html
-      - name: Render OAuth 2.0 Token Exchange Binding Text
-        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml --text
-      - name: Upload OAuth 2.0 Token Exchange Binding artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: oauth-token-exchange
-          path: |
-            authzen-oauth-token-exchange-1_0.html
-            profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml
-
-      - name: Convert Authorization Claims Profile to rfc xml
-        run: kramdown-rfc2629 profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md > profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml
-      - name: Render Authorization Claims Profile HTML
-        run: xml2rfc profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml --html -o authzen-oauth-authorization-claims-1_0.html
-      - name: Render Authorization Claims Profile Text
-        run: xml2rfc profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml --text
-      - name: Upload Authorization Claims Profile artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: oauth-authorization-claims
-          path: |
-            authzen-oauth-authorization-claims-1_0.html
-            profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml
-
-      - name: Convert Authorization API 1.0 Certification Scenario to rfc xml
-        run: kramdown-rfc2629 certification/authorization-api-1_0-scenario.md > certification/authorization-api-1_0-scenario.xml
-      - name: Render Certification Scenario HTML
-        run: xml2rfc certification/authorization-api-1_0-scenario.xml --html -o authorization-api-1_0-certification-scenario.html
-      - name: Render Certification Scenario Text
-        run: xml2rfc certification/authorization-api-1_0-scenario.xml --text
-      - name: Upload Certification Scenario artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: certification-scenario
-          path: |
-            authorization-api-1_0-certification-scenario.html
-            certification/authorization-api-1_0-scenario.xml
+          name: rfc-${{ matrix.name }}
+          path: dist
 
   publish-to-pages:
     if: github.ref == 'refs/heads/main'
@@ -199,56 +98,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Download artifact
+      - uses: actions/checkout@v7
+      - name: Add archived original submission (version 0_0)
+        run: |
+          mkdir -p site
+          cp archive/authorization-api-0_0.html site/
+      - name: Download rendered documents
         uses: actions/download-artifact@v8
         with:
-          pattern: authorization-api-*
-          path: .
+          pattern: rfc-*
+          path: site
           merge-multiple: true
-      - name: Download artifact - pattern document
-        uses: actions/download-artifact@v8
-        with:
-          name: patterns-doc
-      - name: Download artifact - COAZ framework
-        uses: actions/download-artifact@v8
-        with:
-          name: coaz-framework
-      - name: Download artifact - COAZ-MCP binding
-        uses: actions/download-artifact@v8
-        with:
-          name: coaz-mcp-binding
-      - name: Download artifact - MCP profile
-        uses: actions/download-artifact@v8
-        with:
-          name: mcp-profile
-      - name: Download artifact - Access Request Approval profile
-        uses: actions/download-artifact@v8
-        with:
-          name: access-request-approval-profile
-      - name: Download artifact - Obligations profile
-        uses: actions/download-artifact@v8
-        with:
-          name: obligations-profile
-      - name: Download artifact - OAuth 2.0 Token Issuance profile
-        uses: actions/download-artifact@v8
-        with:
-          name: oauth-token-issuance
-      - name: Download artifact - OAuth 2.0 Token Exchange binding
-        uses: actions/download-artifact@v8
-        with:
-          name: oauth-token-exchange
-      - name: Download artifact - Authorization Claims profile
-        uses: actions/download-artifact@v8
-        with:
-          name: oauth-authorization-claims
-      - name: Download artifact - Certification Scenario
-        uses: actions/download-artifact@v8
-        with:
-          name: certification-scenario
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: .
+          path: site
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -43,25 +43,62 @@ Each of these directories contains a README for further instructions.
 
 ## Building the spec
 
-To build the spec locally, you need two tools - `kramdown` (a Ruby gem), and `xml2rfc` (a python tool).
+All of the documents in this repository (the API spec, the design patterns document, the profiles and the certification scenario) are written in markdown and rendered to HTML with two tools - `kramdown-rfc` (a Ruby gem), and `xml2rfc` (a python tool).
 
-The GitHub workflow in `.github/workflows/jekyll-gh-pages.yml` runs on each PR that is merged to `main`, resulting in a new HTML version of the spec hosted at https://openid.github.io/authzen.
+### The publish workflow
+
+The GitHub workflow in `.github/workflows/jekyll-gh-pages.yml` renders every document and publishes the result to https://openid.github.io/authzen.
+
+* On every pull request against `main`, the workflow renders every document as a build check. Nothing is published.
+* On every push to `main` (i.e. each merged PR), the workflow renders every document and then deploys the rendered HTML to GitHub Pages.
+
+Each document is rendered in its own parallel job, driven by a build matrix at the top of the `build-rfc` job. A failure in one document does not stop the others from building, and the failing document is named in the job title (for example `build-rfc (coaz-framework)`).
+
+Each matrix entry has the following fields:
+
+| Field        | Description                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `name`       | A short identifier for the document, used in the job title and the artifact name.               |
+| `source`     | The path to the markdown source, relative to the repository root.                                |
+| `html`       | The file name of the rendered HTML, as it will appear under https://openid.github.io/authzen.    |
+| `extra_html` | (Optional) An additional file name to publish the same HTML under. Only the API spec uses this, to serve as the site's `index.html`. |
+
+The rendered HTML and the intermediate RFC XML for each document are uploaded as a workflow artifact named `rfc-<name>`, so they can be downloaded and inspected from the workflow run for any PR.
+
+### Adding a new document
+
+To publish a new profile or other document, add an entry to the `matrix.include` list in `.github/workflows/jekyll-gh-pages.yml`:
+
+```yaml
+- name: my-new-profile
+  source: profiles/authzen-my-new-profile-1_0.md
+  html: authzen-my-new-profile-1_0.html
+```
+
+Once merged to `main`, the document will be available at `https://openid.github.io/authzen/<html>`. Remember to add a link to it in this README as well.
+
+### Building locally
 
 To build locally, ensure that you have both a Python and Ruby distribution.
 
-### Install dependencies
+#### Install dependencies
 
 ```sh
 gem install kramdown-rfc
 pip install xml2rfc
 ```
 
-### Build the spec
+#### Build a document
+
+The commands below are the same ones the workflow runs. Substitute the `source` and `html` values from the matrix entry for the document you want to build.
 
 ```sh
 # Convert from markdown to XML
 kramdown-rfc2629 api/authorization-api-1_0.md > api/authorization-api-1_0.xml
 
 # Render XML into HTML
-xml2rfc api/authorization-api-1_0.xml --html -o index.html
+xml2rfc api/authorization-api-1_0.xml --html -o authorization-api-1_0.html
+
+# (Optional) Render XML into plain text
+xml2rfc api/authorization-api-1_0.xml --text
 ```


### PR DESCRIPTION
## Problem / Intent

The publish workflow repeats the same convert → render → upload block once per document (8 copies and growing), and the publish job downloads each artifact with its own step. Adding a document means copy-pasting ~25 lines across two jobs, and it's easy to miss one — the COAZ-MCP binding was built but not deployed until #560 added the missing download step.

## Approach

Turn the document list into data: `build-rfc` is now a matrix where each document is a 3-line entry (artifact name, source markdown, output HTML name), sharing a single render/upload step sequence. The main spec's `index.html` copy is a matrix field rather than a dedicated step. Each leg uploads an `rfc-*` artifact whose layout mirrors the published paths, so the publish job collects everything with one pattern download — a new document can never be built-but-not-published again. The archived 0_0 submission is copied straight from the checkout instead of round-tripping through an artifact.

Published output is unchanged: same HTML filenames at the site root, same XML paths, `index.html` still the working draft (verified the artifact layout against the live site's published paths, plus an end-to-end render of the main spec with the same tool versions).

Documents now build in parallel with `fail-fast: false`, so one broken document doesn't mask errors in the others. Note the check names change from `build-rfc` to `build-rfc (<doc>)` — if branch protection pins the old name, it will need updating.