### PR TITLE
Sync evaluation schemas with the final 1.0 text

### DIFF
--- a/api/schemas/evaluation-request.schema.json
+++ b/api/schemas/evaluation-request.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "authzen-evaluation-request",
   "title": "Access Evaluation API Request",
-  "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-the-access-evaluation-api-r",
+  "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-the-access-evaluation-api-r",
   "type": "object",
   "required": [
     "subject",
@@ -12,7 +12,7 @@
   "properties": {
     "subject": {
       "description": "A Subject is the user or machine principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.",
-      "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-subject",
+      "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-subject",
       "type": "object",
       "required": [
         "type",
@@ -49,7 +49,7 @@
     },
     "resource": {
       "description": "A Resource is the target of an access request.",
-      "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-resource",
+      "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-resource",
       "type": "object",
       "required": [
         "type",
@@ -80,7 +80,7 @@
     },
     "action": {
       "description": "A Subject is the user or machine principal about whom the Authorization API is being invoked. The Subject may be requesting access at the time the Authorization API is invoked.",
-      "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-action",
+      "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-action",
       "type": "object",
       "required": [
         "name"
@@ -98,7 +98,7 @@
     },
     "context": {
       "description": "The Context object is a set of attributes that represent environmental or contextual data about the request such as time of day. It is a JSON ([RFC8259]) object.",
-      "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-context",
+      "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-context",
       "type": "object",
       "example": [
         {
@@ -107,7 +107,6 @@
       ]
     }
   },
-  "additionalProperties": false,
   "examples": [
     {
       "subject": {

--- a/api/schemas/evaluation-response.schema.json
+++ b/api/schemas/evaluation-response.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "authzen-evaluation-response",
   "title": "Access Evaluation API Response",
-  "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-the-access-evaluation-api-re",
+  "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-the-access-evaluation-api-re",
   "type": "object",
   "required": [
     "decision"
@@ -10,30 +10,13 @@
   "properties": {
     "decision": {
       "description": "A boolean value that specifies whether the Decision is to allow or deny the operation.",
-      "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-access-evaluation-decision",
+      "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-decision",
       "type": "boolean"
     },
     "context": {
-      "$comment": "https://openid.net/specs/authorization-api-1_0-01.html#name-access-evaluation-decision",
-      "type": "object",
-      "required": [
-        "id"
-      ],
-      "properties": {
-        "id": {
-          "description": "A string value that specifies the reason within the scope of a particular response.",
-          "type": "string"
-        },
-        "reason_admin": {
-          "description": "The reason, which MUST NOT be shared with the user, but useful for administrative purposes that indicates why the access was denied.",
-          "type": "object"
-        },
-        "reason_user": {
-          "description": "The reason, which MAY be shared with the user that indicates why the access was denied.",
-          "type": "object"
-        }
-      },
-      "additionalProperties": false
+      "description": "An object which can convey additional information that can be used by the PEP as part of the decision enforcement process.",
+      "$comment": "https://openid.net/specs/authorization-api-1_0.html#name-decision-context",
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
The schemas under `api/schemas/` still encode the draft-01 model, and reject the specification's own examples.

`evaluation-response.schema.json` constrains the Decision `context` to the draft-01 Reasons object, requiring an `id` member and forbidding anything else. Section 5.5.1 defines `context` as an object with no required members, and Section 5.5.2 places its semantics and format outside the scope of the specification. `evaluation-request.schema.json` sets `additionalProperties: false`, contradicting Section 10.1.1: receivers MUST ignore unknown fields. The `$comment` anchors point at `authorization-api-1_0-01.html`, and two of them use `#name-access-evaluation-decision`, which no longer resolves in the published document.

This relaxes `context` to a plain object, drops `additionalProperties: false` from the request schema, and repoints the anchors.

Checked with Draft 2020-12: the Section 7.2 and 7.1.2.1 response examples and the Obligations profile `context.obligations` shape are rejected before and accepted after.

Fixes #598.