### PR TITLE
Add the OAuth 2.0 token issuance profile family

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -132,6 +132,48 @@ jobs:
             authzen-obligations-profile-1_0.html
             profiles/authzen-obligations-profile-1_0.xml
 
+      - name: Convert OAuth 2.0 Token Issuance Profile to rfc xml
+        run: kramdown-rfc2629 profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md > profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml
+      - name: Render OAuth 2.0 Token Issuance Profile HTML
+        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml --html -o authzen-oauth-token-issuance-1_0.html
+      - name: Render OAuth 2.0 Token Issuance Profile Text
+        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml --text
+      - name: Upload OAuth 2.0 Token Issuance Profile artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: oauth-token-issuance
+          path: |
+            authzen-oauth-token-issuance-1_0.html
+            profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.xml
+
+      - name: Convert OAuth 2.0 Token Exchange Binding to rfc xml
+        run: kramdown-rfc2629 profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md > profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml
+      - name: Render OAuth 2.0 Token Exchange Binding HTML
+        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml --html -o authzen-oauth-token-exchange-1_0.html
+      - name: Render OAuth 2.0 Token Exchange Binding Text
+        run: xml2rfc profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml --text
+      - name: Upload OAuth 2.0 Token Exchange Binding artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: oauth-token-exchange
+          path: |
+            authzen-oauth-token-exchange-1_0.html
+            profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.xml
+
+      - name: Convert Authorization Claims Profile to rfc xml
+        run: kramdown-rfc2629 profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md > profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml
+      - name: Render Authorization Claims Profile HTML
+        run: xml2rfc profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml --html -o authzen-oauth-authorization-claims-1_0.html
+      - name: Render Authorization Claims Profile Text
+        run: xml2rfc profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml --text
+      - name: Upload Authorization Claims Profile artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: oauth-authorization-claims
+          path: |
+            authzen-oauth-authorization-claims-1_0.html
+            profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.xml
+
       - name: Convert Authorization API 1.0 Certification Scenario to rfc xml
         run: kramdown-rfc2629 certification/authorization-api-1_0-scenario.md > certification/authorization-api-1_0-scenario.xml
       - name: Render Certification Scenario HTML
@@ -187,6 +229,18 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: obligations-profile
+      - name: Download artifact - OAuth 2.0 Token Issuance profile
+        uses: actions/download-artifact@v8
+        with:
+          name: oauth-token-issuance
+      - name: Download artifact - OAuth 2.0 Token Exchange binding
+        uses: actions/download-artifact@v8
+        with:
+          name: oauth-token-exchange
+      - name: Download artifact - Authorization Claims profile
+        uses: actions/download-artifact@v8
+        with:
+          name: oauth-authorization-claims
       - name: Download artifact - Certification Scenario
         uses: actions/download-artifact@v8
         with:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ COAZ-MCP is the COAZ binding for the Model Context Protocol (MCP), defining how 
 A profile that specifies an approval workflow for handling denials in a structured way.
 The HTML version is available [here](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html)
 
+## Draft OAuth 2.0 Token Issuance Profile
+
+A profile for using the AuthZEN Authorization API to externalize an authorization server's decision to issue a token, and to let the decision response shape what is issued. It is at `profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md`. The HTML version is available [here](https://openid.github.io/authzen/authzen-oauth-token-issuance-1_0.html).
+
+## Draft OAuth 2.0 Token Exchange Binding
+
+The binding of the token issuance profile to OAuth 2.0 Token Exchange, covering delegation, impersonation, identity chaining, ID-JAG and Transaction Tokens. It is at `profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md`. The HTML version is available [here](https://openid.github.io/authzen/authzen-oauth-token-exchange-1_0.html).
+
+## Draft Authorization Claims Profile
+
+A profile that sources the `groups`, `roles` and `entitlements` claims of a JWT access token from AuthZEN Resource Search rather than from a directory or a vendor-specific hook. It is at `profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md`. The HTML version is available [here](https://openid.github.io/authzen/authzen-oauth-authorization-claims-1_0.html).
+
 ## Interop harness
 
 The `interop` directory contains the interoperability scenarios for AuthZEN. Currently, there is a single scenario based on a "Todo" application. The scenario spec and results can be viewed [here](https://authzen-interop.net).

--- a/profiles/Makefile
+++ b/profiles/Makefile
@@ -25,3 +25,12 @@ all:
 	@ $(MAKE) authzen-access-request-approval/authzen-access-request-approval-profile-1_0.xml
 	@ $(MAKE) authzen-access-request-approval/authzen-access-request-approval-profile-1_0.html
 	@ $(MAKE) authzen-access-request-approval/authzen-access-request-approval-profile-1_0.txt
+	@ $(MAKE) authzen-oauth/authzen-oauth-token-issuance-1_0.xml
+	@ $(MAKE) authzen-oauth/authzen-oauth-token-issuance-1_0.html
+	@ $(MAKE) authzen-oauth/authzen-oauth-token-issuance-1_0.txt
+	@ $(MAKE) authzen-oauth/authzen-oauth-token-exchange-1_0.xml
+	@ $(MAKE) authzen-oauth/authzen-oauth-token-exchange-1_0.html
+	@ $(MAKE) authzen-oauth/authzen-oauth-token-exchange-1_0.txt
+	@ $(MAKE) authzen-oauth/authzen-oauth-authorization-claims-1_0.xml
+	@ $(MAKE) authzen-oauth/authzen-oauth-authorization-claims-1_0.html
+	@ $(MAKE) authzen-oauth/authzen-oauth-authorization-claims-1_0.txt

--- a/profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md
+++ b/profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md
@@ -1,0 +1,881 @@
+---
+title: "AuthZEN Profile for Authorization Claims in JWT Access Tokens - Draft 1"
+abbrev: "AuthZEN Authorization Claims"
+category: std
+ipr: none
+
+docname: authzen-oauth-authorization-claims-1_0
+workgroup: OpenID AuthZEN
+consensus: true
+v: 3
+stand_alone: true
+smart_quotes: no
+pi: [toc, sortrefs, symrefs, private]
+keyword:
+ - oauth
+ - authorization
+ - authzen
+ - policy
+ - claims
+ - search
+
+author:
+ -
+    fullname: "Omri Gazitt"
+    organization: "Independent"
+    email: "ogazitt@gmail.com"
+
+normative:
+  RFC6749:
+  RFC7519:
+  RFC7643:
+  RFC9068:
+  AUTHZEN:
+    title: "Authorization API 1.0"
+    target: "https://openid.net/specs/authorization-api-1_0-final.html"
+    date: 2026-01-11
+    author:
+      - ins: "OpenID Foundation AuthZEN Working Group"
+        org: "OpenID Foundation"
+  ISSUANCE: I-D.gazitt-oauth-authzen-issuance
+
+informative:
+  I-D.gazitt-oauth-authzen-token-exchange:
+
+--- abstract
+
+RFC 9068 recommends that an authorization server placing group memberships,
+roles, or entitlements in a JWT access token draw those claims from the SCIM
+user schema. It says what the claims are named and how their values are
+encoded, and it does not say where an authorization server obtains them. In
+deployments today they come from a directory, a database, or a
+vendor-specific hook, and the question they answer is an authorization
+question asked of something that is not the authorization system.
+
+This document profiles the Resource Search API of the OpenID AuthZEN
+Authorization API for that purpose. It binds each authorization claim to a
+search, defines how a search result set becomes a claim value, and requires
+that a search result never influence whether a token is issued or what
+authority it conveys. It may be applied on its own, by an authorization
+server that externalizes claim enrichment but not its issuance decision, or
+alongside the companion framework document that externalizes the decision.
+
+--- middle
+
+# Introduction
+
+{{RFC9068}} Section 2.2.3.1 describes the authorization attributes an
+authorization server (AS) commonly places in a JWT access token beyond the
+delegated authority the grant itself conveys: the group memberships, roles,
+and entitlements a resource server is expected to consult. It recommends the
+`groups`, `roles`, and `entitlements` attributes of the user schema of
+{{RFC7643}} as the claim types, and registers all three as JWT claims.
+
+What it does not describe is where the values come from. An AS populating
+`groups` is answering the question "which groups does this subject belong
+to." That is an authorization question, and in most deployments it is
+answered by a directory query, a database join, or a proprietary extension
+point rather than by the system that holds the deployment's authorization
+policy.
+
+{{AUTHZEN}} answers questions of exactly that shape. Its Resource Search API
+returns the resources of a given type on which a given subject may perform a
+given action. Given a subject and a `member` action, the resources of type
+`group` it returns are the groups the subject is a member of.
+
+This document defines the bindings that make that correspondence
+interoperable, and the rules an AS follows to turn a search result into a
+claim.
+
+## Why a Search {#division}
+
+{{AUTHZEN}} defines a Search API for enumerating one leg of a tuple given the
+other two, and enumerating what a subject holds is that operation exactly.
+
+The alternative would be to obtain these claims as a side effect of an
+evaluation, attaching the enumeration to the response context of a decision
+the AS was making anyway. {{ISSUANCE}} defines a `claims` key that could be
+used that way, and declines to route these claims through it. An evaluation
+response is the answer to the question the request asked, and an AS asking
+whether a token may be issued has not asked what its subject belongs to. A
+purpose-built operation exists for the second question, so the second
+question is asked with it.
+
+So the AS makes each call for what it is for, and composes the results. The
+consequence is worth stating at the outset: **this document asks nothing of a
+PDP that {{AUTHZEN}} does not already require.** The searches it specifies
+are ordinary Resource Search requests carrying registered type and action
+names, and a PDP answering them is not required to know that their results
+will reach a token. Everything specified here is a rule for the authorization
+server.
+
+## Composition with the Issuance Framework {#relationship}
+
+This document is independent of {{ISSUANCE}}. An AS that does not externalize
+its issuance decision may still externalize claim enrichment, and for such an
+AS everything in this document applies unchanged; the decision to issue is
+simply its own.
+
+Where both are used, they compose as follows:
+
+* The decision governs. A token is minted only if the gate of {{ISSUANCE}}
+  permits it, and no search result contributes to that decision
+  ({{ordering}}).
+* Enrichment is discardable. Where the gate denies, any search results the AS
+  has obtained are discarded and no claim is rendered from them.
+
+{{ISSUANCE}} defines no vocabulary this document extends, and this document
+defines none of its own, so the two interact only through that ordering.
+
+Where the grant is a member of the token exchange family,
+{{I-D.gazitt-oauth-authzen-token-exchange}} determines the subject, and the
+searches of this document follow it ({{search-subject}}).
+
+## Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+This document uses the terms Authorization Server, Client, Resource Server,
+access token, and scope from {{RFC6749}}; Policy Decision Point (PDP), Policy
+Enforcement Point (PEP), Subject, Action, Resource, and Context from
+{{AUTHZEN}}; and gate tuple and scope tuple from {{ISSUANCE}}.
+
+Authorization claim:
+: One of the claims of {{RFC9068}} Section 2.2.3.1 - `groups`, `roles`, and
+  `entitlements` - or any other claim whose value enumerates what a subject
+  holds.
+
+Claim binding:
+: The association of an authorization claim with an AuthZEN resource type and
+  action name, such that a Resource Search over that type and action
+  enumerates the claim's members. See {{bindings}}.
+
+Bound claim:
+: An authorization claim for which the AS has a claim binding configured, and
+  which it will therefore attempt to populate on the token it is about to
+  issue.
+
+# Applicability
+
+This document applies to an authorization server that populates one or more
+authorization claims in a token it issues by querying an AuthZEN PDP.
+Implementing {{ISSUANCE}} is not a prerequisite. The two address different
+halves of an issuance, a deployment may adopt either without the other, and
+{{relationship}} governs the case where it adopts both.
+
+The bindings of {{bindings}} are keyed by claim name and say nothing about
+token type. An AS that places the same claims in an artifact other than a JWT
+access token may use them, though {{RFC9068}}, which is what makes these
+particular claim names interoperable, governs access tokens.
+
+# Architecture {#architecture}
+
+~~~ ascii-art
++--------+           +----------------------+        +-------+
+| Client |           | Authorization Server |        |  PDP  |
++---+----+           |        (PEP)         |        +---+---+
+    |                +----------+-----------+            |
+    | 1. token req              |                        |
+    +-------------------------->|                        |
+    |                           | 2. evaluate (ISSUANCE) |
+    |                           +----------------------->|
+    |                           |                        |
+    |                           | 3. search: groups      |
+    |                           +----------------------->|
+    |                           | 4. search: roles       |
+    |                           +----------------------->|
+    |                           |                        |
+    |                           | 5. decision            |
+    |                           |<-----------------------+
+    |                           | 6. result sets         |
+    |                           |<-----------------------+
+    |                           |                        |
+    |                           | 7. if permitted, mint  |
+    |                           |    and render claims   |
+    | 8. token response         |                        |
+    |<--------------------------+                        |
+~~~
+
+Steps 3 and 4 are drawn as concurrent with step 2 because {{ordering}}
+permits it. They are semantically after it: their results are discarded if
+step 5 denies.
+
+Step 2 is one request under {{ISSUANCE}}, ordinarily a batch. Each bound
+claim is a separate search, because a Resource Search names one resource type
+and {{AUTHZEN}} defines no batch form for searches.
+
+# Claim Bindings {#bindings}
+
+## Membership as an Action {#relations}
+
+A claim binding names an AuthZEN action. The names this document registers -
+`member`, `assignee`, `holder` - describe how a subject relates to a resource
+rather than an operation the subject performs on it.
+
+Nothing in {{AUTHZEN}} requires otherwise. An action names something asserted
+of a subject and a resource together, and "Alice is a member of engineering"
+fills the three positions of a tuple as readily as "Alice may read document
+7" does. How a deployment's PDP arrives at either answer is its own affair.
+
+The names are consequently meaningful in an evaluation as well as in a
+search, which is what makes a search result checkable. {{AUTHZEN}} Section
+8.1 states that a search result, used in a subsequent evaluation, SHOULD
+yield a permit; an AS or an auditor can verify any member of a rendered claim
+by evaluating the corresponding tuple.
+
+## Registered Bindings {#registered}
+
+This document registers the following bindings in the registry established in
+{{iana-bindings}}:
+
+| Claim | `resource.type` | `action.name` |
+|---|---|---|
+| `groups` | `group` | `member` |
+| `roles` | `role` | `assignee` |
+| `entitlements` | `entitlement` | `holder` |
+
+Reading the first row: the members of the `groups` claim are the identifiers
+of the resources of type `group` on which the subject may perform the action
+`member`.
+
+Each action name matches the grammar {{ISSUANCE}} defines for registered
+action names, `[a-z][a-z0-9_]{0,30}`. They are not composed with the `issue:`
+prefix, which {{ISSUANCE}} reserves for gate actions.
+
+> **Editor's note.** `member` is the settled choice of the three. It is the
+> name {{RFC7643}} uses, and it is what schema languages call this
+> association in their own examples. `assignee` and `holder` are less
+> settled: a role or an entitlement is variously said to be assigned to,
+> granted to, or held by a subject, and a single name could serve for both
+> claims, with the resource type carrying the distinction. Distinct names are
+> registered here on the theory that policy is easier to read when names
+> differ where the concepts do. Implementer feedback is invited.
+
+## Deployment Configuration {#configuration}
+
+A deployment that uses action names other than the registered ones
+configures the AS with the names it uses. The registered bindings are
+defaults, not constraints on a deployment's policy vocabulary.
+
+They earn their place by being defaults. An AS and a PDP from different
+implementers, neither configured for the other, interoperate on these three
+claims only because both arrive at `group`/`member` without being told. A
+deployment that overrides a binding has taken on the configuration burden
+knowingly, which is a reasonable trade and a poor default.
+
+A deployment MAY also bind a claim this document does not register, using a
+binding registered under {{iana-bindings}} or one local to the deployment. A
+local binding is not interoperable and SHOULD NOT use a claim name registered
+in the JSON Web Token Claims registry for some other purpose.
+
+# Forming the Search Request {#request}
+
+For each bound claim, the AS forms one Resource Search request as defined in
+Section 8.5 of {{AUTHZEN}}.
+
+## Subject {#search-subject}
+
+The `subject` of every search MUST be the same entity as the subject of the
+gate tuple of {{ISSUANCE}}: the same `type` and the same `id`, the latter
+being the identifier the AS intends to place in the issued token's subject
+claim.
+
+The requirement is not merely for tidiness. A claim enumerating what a
+subject holds is only true of the subject the token names, and any identifier
+transformation the AS applies - pairwise identifiers, resolution of a foreign
+identity to a local account - MUST therefore be applied before the search is
+formed, exactly as {{ISSUANCE}} requires of the evaluation.
+
+Where {{I-D.gazitt-oauth-authzen-token-exchange}} applies, the subject is the
+exchange subject and never the requesting party. The token represents the
+subject, and a claim enumerating the requesting party's holdings would assert
+of the subject something that is not true of it.
+
+## Action and Resource
+
+`action.name` MUST be the action name of the claim binding, and
+`resource.type` MUST be its resource type. The `resource` object carries no
+`id`; Section 8.5.1 of {{AUTHZEN}} states that the identifier of the entity
+being searched for is omitted, and is ignored if present.
+
+## Context {#search-context}
+
+An AS SHOULD convey in the search `context` the same values it conveys on the
+evaluation request under {{ISSUANCE}}. It MAY additionally convey:
+
+| Key | Type | Value |
+|---|---|---|
+| `audience` | array of strings | The issuance targets of the token being minted |
+
+The type is an array for the same reason {{ISSUANCE}} makes its `audience`
+shaping key an array: the value is a set, and a set has one JSON rendering
+here.
+
+This key exists because {{RFC9068}} scopes its authorization claims to the
+target, describing roles and groups "relevant to the resource being accessed"
+and entitlements "for the targeted resource," while a Resource Search has no
+slot to say so. Its mandatory entities are the subject, the action, and the
+type of the resource being enumerated; the resource identifier position is
+the answer, not an input. There is no second resource.
+
+The consequence is that this is advisory input, and this document does not
+pretend otherwise. A PDP MAY use it to scope the result set and MAY ignore
+it, so an AS MUST NOT assume the returned set has been filtered by target,
+and MUST NOT represent the resulting claim to itself as target-scoped. A
+deployment that requires the scoping to be honored registers a binding whose
+resource type distinguishes the target, which puts the distinction in the
+type slot where a PDP must read it.
+
+## Endpoint Selection
+
+Where the HTTPS binding of {{AUTHZEN}} is in use, the request is sent to the
+`search_resource_endpoint` published in the PDP's metadata, or to
+`/access/v1/search/resource` where metadata provides no value.
+
+Section 9.1.1 of {{AUTHZEN}} states that the absence of an endpoint parameter
+is sufficient for a PEP to determine that the PDP does not support the
+corresponding API. An AS whose PDP publishes metadata without
+`search_resource_endpoint`, and which has not been configured with an
+endpoint out of band, MUST NOT attempt the searches; every bound claim then
+fails under {{failure}}. This is a deployment error rather than a request
+error, and an AS SHOULD detect it at configuration time rather than at the
+token endpoint.
+
+# Ordering {#ordering}
+
+**An AS MUST NOT include an enrichment claim in a token it does not issue,
+and MUST NOT treat a search result as authorizing anything.** In particular,
+an AS MUST NOT derive the `scope` claim, the audience, or
+`authorization_details` from search results, and MUST NOT allow a search
+result to affect whether it issues a token or what authority that token
+conveys. Where {{ISSUANCE}} is in use, this means a search result never
+affects the gate or scope decisions.
+
+An AS MAY nonetheless issue the searches concurrently with whatever it does
+to decide, discarding their results if it decides not to issue.
+
+The two statements are compatible, and it is worth being precise about why,
+because they look like a contradiction. The ordering is semantic: search
+results are inputs to claim construction and to nothing else, so no ordering
+of the calls in time can make one an input to the decision. The concurrency
+is a performance affordance: the calls are independent, and running them in
+sequence would add their latencies together on the token endpoint's critical
+path.
+
+Two consequences follow for a deployment that takes the affordance. It
+performs work it may discard, so the cost of a denied request rises by the
+cost of the searches. And its PDP receives searches for subjects who never
+receive a token, so search volume at the PDP is not a measure of tokens
+issued, and neither logs nor rate limits should be read as though it were.
+
+# Rendering the Claim {#rendering}
+
+A Search API response, per Section 8.3 of {{AUTHZEN}}, carries a `results`
+array of entities of the type searched for, each an object with a `type` and
+an `id`. A claim value is a JSON array. This section defines the mapping
+between them.
+
+## From Results to Claim Members {#members}
+
+The value of a bound claim MUST be a JSON array of strings, each member being
+the `id` of one result object, and every result contributing exactly one
+member.
+
+{{RFC9068}} recommends encoding these claims according to the guidance of
+{{RFC7643}}, whose corresponding attributes are multi-valued and complex:
+each value is an object with a `value` sub-attribute carrying the identifier,
+and, depending on the attribute, `$ref`, `display`, `type`, and `primary`
+sub-attributes carrying a reference, a human-readable label, and
+classification.
+
+An AuthZEN search result supplies exactly one of those: the identifier, in
+`id`. The `type` field of a result is invariant across the response by
+construction, since the search named it and Section 8.3 of {{AUTHZEN}}
+requires results to be of that type alone, so it carries no per-member
+information. The remaining sub-attributes have no source in a search result
+and could only be fabricated or fetched from a system this profile does not
+define. A conforming complex rendering would therefore be an array of
+single-member objects, conveying what an array of strings conveys, in a claim
+that is carried on every request the token is presented with.
+
+This document accordingly renders the array of identifiers directly. The
+recommendation in {{RFC9068}} is a SHOULD, and this document deviates from it:
+the profile emits the `value` sub-attribute of each SCIM value and omits an
+enclosing object that would have nothing else in it. An AS that must produce
+the complex form for a resource server that requires it is not prevented from
+doing so, but it is then rendering something this profile does not define,
+and a resource server cannot infer which form to expect from the presence of
+this profile.
+
+## Type Mismatch {#type-mismatch}
+
+An AS MUST reject a result whose `type` does not equal the `resource.type` it
+searched for, and MUST treat the response as a failed search under
+{{failure}} rather than filtering the offending results and proceeding.
+
+## Duplicates and Order {#dedup}
+
+A result set is a set. An AS MUST remove duplicates, comparing `id` values as
+JSON strings for exact equality, before rendering the claim. Duplicates are
+expected rather than exceptional: {{AUTHZEN}} recommends that searches be
+performed transitively, so a subject holding the same group through two paths
+may be returned twice, and pagination admits repetition on its own account
+({{pagination}}).
+
+A JSON array is ordered and a set is not, so the order of the members carries
+no meaning. A resource server MUST NOT attribute any to it.
+
+An AS SHOULD nonetheless render members in an order that is stable across
+issuances, so that two tokens issued for the same subject against unchanged
+policy data differ only where the underlying facts differ. Sorting
+ascending by Unicode code point is one way; preserving the PDP's response
+order is another where the PDP's order is itself stable.
+
+## Empty Result Sets {#empty}
+
+Where a bound claim's search succeeds and returns no results, the AS MUST
+include the claim with an empty array as its value. It MUST NOT omit the
+claim.
+
+The choice is observable, so it has to be made deliberately. Under this rule
+the presence of a bound claim means the enumeration was performed, and its
+absence means the claim was not populated. Had an empty result set also been
+rendered as absence, a resource server could not distinguish "this subject
+holds nothing" from "the enumeration did not happen."
+
+# Pagination {#pagination}
+
+A PDP MAY paginate a search response. Section 8.2 of {{AUTHZEN}} defines the
+mechanism: a response that does not carry the entire result set includes a
+`page` object with a non-empty opaque `next_token`, and the PEP retrieves the
+next page by repeating the request with `page.token` set to that value, until
+a response carries an empty `next_token`. Apart from the token, every value
+in the request MUST remain identical across pages, and a PDP is entitled to
+return an error if one changes.
+
+Section 8.2 of {{AUTHZEN}} states that pagination does not guarantee an
+atomic snapshot, and that consequently, if items are added or removed while
+paginating, results MAY be repeated or omitted between pages. A claim
+assembled from a paginated response is therefore a best-effort enumeration:
+the AS deduplicates across the whole set of pages rather than within each
+({{dedup}}), and an item added or removed mid-pagination may be reflected in
+the claim or not.
+
+An AS SHOULD bound the number of pages it will follow for a single claim, so
+that an unexpectedly large enumeration does not stall the token endpoint, and
+where that bound is exceeded it treats the search as failed under
+{{failure}}. Reaching such a bound is a sign that the data belongs at the
+resource server rather than in the token; see {{token-size}}.
+
+# Failure Handling {#failure}
+
+A bound claim's search fails if the PDP returns an error status, if the
+response is malformed or contains a result of the wrong type
+({{type-mismatch}}), if the page bound is exceeded ({{pagination}}), if the
+request times out, or if the PDP cannot be reached.
+
+Where a bound claim's search fails, the AS **MUST NOT** render the claim, and
+**MUST NOT** substitute a default, a placeholder, or an empty array for it.
+An empty array asserts that the subject holds nothing ({{empty}}), which a
+failed search does not establish.
+
+Whether the AS then issues a token without the claim, or issues none, is a
+deployment decision, and this document specifies no default. An AS SHOULD
+allow the choice to be configured per claim binding and per client, because
+the correct answer differs by claim and by consumer: the absence of a claim
+a resource server reads before granting access is a different event from the
+absence of one used for display or personalization, and only the deployment
+knows which it has.
+
+> **Implementer's note.** Issuing the token without the claim is the common
+> behavior in authorization servers that support enrichment today, and it is
+> a defensible default: an enrichment dependency that is briefly unreachable
+> should not take down every token issuance that names the claim. The case
+> that argues the other way is a resource server that reads the claim as an
+> input to an access decision and treats its absence as a value rather than
+> as an absence. An AS cannot detect that from the request, so the choice
+> belongs with the operator, stated rather than assumed, and the two
+> behaviors should be nameable in configuration rather than implied by the
+> product's default.
+
+An AS MAY serve a bound claim from a cache of an earlier successful search. A
+cache hit is not a failure. Cached results are subject to the staleness
+discussed in {{consistency}}, and a deployment that caches SHOULD bound the
+cache lifetime by the lifetime of the tokens the results are rendered into.
+
+# Discovery
+
+This document registers no capability URN.
+
+{{ISSUANCE}} draws the line at response vocabulary: an extension that adds
+keys an AS must understand and enforce registers a URN, and one that does not
+relies on the mechanisms already in place. This document adds no response
+vocabulary at all, and, as {{division}} notes, requires nothing of a PDP that
+{{AUTHZEN}} does not already require. What an AS needs to discover is
+therefore already discoverable:
+
+* whether the PDP supports Resource Search at all is answered by the presence
+  of `search_resource_endpoint` in its metadata, which Section 9.1.1 of
+  {{AUTHZEN}} defines for exactly this purpose;
+* what the bindings mean is answered by the registry of {{iana-bindings}},
+  which is what makes an unconfigured pairing interoperate.
+
+What remains is a question about the content of a deployment's policy: does
+this PDP actually recognize `member` as an action on resources of type
+`group`, or will a correctly formed search return nothing forever? As
+{{ISSUANCE}} argues for the analogous question about gate actions, that
+belongs on the authenticated evaluation surface rather than in an
+unauthenticated metadata document, and the Action Search API of {{AUTHZEN}}
+answers it: a search for the actions a representative subject may perform on
+a representative resource of type `group` returns `member` where the binding
+is live. This is a deployment-time check, and nothing in this document
+requires it.
+
+# Error Mapping
+
+| Condition | Authorization server behavior |
+|---|---|
+| Gate evaluation denied ({{ISSUANCE}}) | Fail per {{ISSUANCE}}; discard results |
+| Result of the wrong type | Treat as a failed search |
+| Page bound exceeded | Treat as a failed search |
+| Search endpoint not published | Treat as a failed search |
+| Search failed | Do not render the claim; issue or fail per configuration |
+
+A failed search that prevents issuance is a fault in the authorization
+server's dependencies rather than a defect in the client's request, and the
+token endpoint error codes of Section 5.2 of {{RFC6749}} all describe the
+latter. No registered code fits. An AS SHOULD therefore respond with an HTTP
+500 status, MUST NOT select a code that attributes the failure to the
+client's request, and MUST NOT disclose which claim failed. {{ISSUANCE}}
+names no code either for the case of a PDP that cannot be reached at all;
+the two conditions are the same condition and should be answered together.
+
+# Example
+
+An authorization code request for two scopes, at a deployment that binds all
+three registered claims. Only the JSON payloads are shown; as {{ISSUANCE}}
+notes, the transport is a property of the deployment.
+
+The token request:
+
+~~~ http-message
+POST /token HTTP/1.1
+Host: as.example
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code=SplxlOBeZQQYbYS6WxSbIA
+&redirect_uri=https%3A%2F%2Fclient.example%2Fcb
+&scope=files.read+files.write
+~~~
+
+The AS forms the evaluation of {{ISSUANCE}} and the three searches, and MAY
+send them concurrently. The evaluation:
+
+~~~ json
+{
+  "subject":  { "type": "user", "id": "U0405936" },
+  "resource": {
+    "type": "audience",
+    "id": "https://api.example/files"
+  },
+  "context": {
+    "client_id": "chatterbox",
+    "acr": "urn:example:loa:2"
+  },
+  "evaluations": [
+    {
+      "action": {
+        "name": "issue:access_token:authorization_code"
+      }
+    },
+    { "action": { "name": "files.read"  } },
+    { "action": { "name": "files.write" } }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+The `groups` search, sent to the PDP's `search_resource_endpoint`:
+
+~~~ json
+{
+  "subject":  { "type": "user", "id": "U0405936" },
+  "action":   { "name": "member" },
+  "resource": { "type": "group" },
+  "context": {
+    "client_id": "chatterbox",
+    "acr": "urn:example:loa:2",
+    "audience": ["https://api.example/files"]
+  }
+}
+~~~
+
+~~~ json
+{
+  "results": [
+    { "type": "group", "id": "engineering" },
+    { "type": "group", "id": "release-managers" }
+  ]
+}
+~~~
+
+The `roles` search differs only in its action and resource type:
+
+~~~ json
+{
+  "subject":  { "type": "user", "id": "U0405936" },
+  "action":   { "name": "assignee" },
+  "resource": { "type": "role" },
+  "context": {
+    "client_id": "chatterbox",
+    "acr": "urn:example:loa:2",
+    "audience": ["https://api.example/files"]
+  }
+}
+~~~
+
+~~~ json
+{
+  "results": [
+    { "type": "role", "id": "deployer" }
+  ]
+}
+~~~
+
+The `entitlements` search is formed the same way, with action `holder` and
+resource type `entitlement`, and returns no results:
+
+~~~ json
+{
+  "results": []
+}
+~~~
+
+The evaluation permits the gate and both scopes:
+
+~~~ json
+{
+  "evaluations": [
+    { "decision": true },
+    { "decision": true },
+    {
+      "decision": true,
+      "context": { "issuance": { "token_lifetime": 3600 } }
+    }
+  ]
+}
+~~~
+
+The AS mints the access token. Its payload:
+
+~~~ json
+{
+  "iss": "https://as.example",
+  "sub": "U0405936",
+  "aud": "https://api.example/files",
+  "client_id": "chatterbox",
+  "iat": 1791000000,
+  "exp": 1791003600,
+  "scope": "files.read files.write",
+  "groups": ["engineering", "release-managers"],
+  "roles": ["deployer"],
+  "entitlements": []
+}
+~~~
+
+`entitlements` is present and empty because its search succeeded and returned
+nothing ({{empty}}). Had it instead failed, the claim would be absent rather
+than empty, and whether a token was issued at all would depend on how the
+deployment has configured that binding ({{failure}}).
+
+Had the gate been denied, the searches would have been performed and their
+results discarded, and no token would have been issued ({{ordering}}).
+
+# Security Considerations
+
+Where {{ISSUANCE}} is also in use, its considerations apply in full.
+
+## Enrichment Is Not Authorization
+
+The rule of {{ordering}} is the security property this document rests on.
+Section 8.1 of {{AUTHZEN}} is careful to say that a search result SHOULD, not
+MUST, correspond to a permit, because a search and an evaluation may be
+computed differently and may consider different variables. An AS that treated
+a non-empty result set as a reason to issue would be relying on a guarantee
+{{AUTHZEN}} declines to make, and would have replaced a decision with an
+enumeration.
+
+The concurrency permitted by {{ordering}} makes this easier to get wrong in
+an implementation than in a specification. Search results become available
+before the decision does, and an implementation that assembles a token as
+results arrive can find itself with a nearly complete token and no decision.
+The results are inputs to claim construction alone.
+
+## No Consistency Across Calls {#consistency}
+
+The decision and the searches are separate requests against data that may
+change between them, so a token can carry a decision made against one state
+and claims computed against another. An AS keeps the window narrow by
+issuing the calls concurrently ({{ordering}}) and by bounding any cache
+lifetime to the lifetime of the tokens the results are rendered into.
+
+## Provenance and Freshness {#provenance}
+
+A claim rendered by this profile carries no indication that it was rendered
+by this profile. A resource server reading `groups` cannot distinguish a value
+the AS obtained from a PDP at issuance from one cached at session
+establishment or copied from an upstream token, and those have different
+revocation behavior. What the profile improves is the AS's side of it: the
+value now comes from a named PDP through a specified API rather than from an
+unspecified directory, database, or hook. The token records none of that.
+
+Nor is the instant at which the underlying state held establishable from the
+token. An AS asserting that these were the subject's groups at 14:02 is making
+two claims of different kinds in one artifact. The first, that it issued the
+token, is authoritative because it issued it. The second is an account of what
+a third party's state contained at a moment only the AS observed, and the AS
+is the party whose caching and propagation behavior a resource server would be
+trying to evaluate. Trusting an issuer does not make it a witness to its own
+freshness.
+
+This document therefore defines no provenance or freshness claim. A value the
+AS asserts about its own timeliness would be relied on as though it were
+verifiable, and it would not be. Meeting the requirement takes an attestation
+from the party that holds the state, which is a signing relationship between
+that party and the resource server rather than a claim an AS can mint.
+
+The property is not created here. It holds for every authorization claim in an
+{{RFC9068}} access token, and for `auth_time`, `acr`, and `amr` in an ID
+Token, all of which are the issuer's account of an event only the issuer
+observed. Where a resource server needs a decision against current state
+rather than an account of past state, the surface for it is the one named in
+{{token-size}}: call the PDP at request time, with the resource in hand.
+
+## Token Size {#token-size}
+
+A claim with thousands of members produces a token that may exceed the
+header size limits of intermediaries on the path to the resource server, at
+which point the failure moves from the AS to the network and becomes much
+harder to diagnose. A deployment discovering that an enumeration is too large
+to carry has learned that the claim is the wrong mechanism for that data, not
+that it needs a larger token. The alternative is available and is the
+ordinary AuthZEN deployment: the resource server consults the PDP directly at
+request time, with the resource in hand, and asks a question whose answer is
+one decision rather than an enumeration. Issuance-time claims and
+request-time evaluation are complementary surfaces, and a claim that will not
+fit in a token is a signal about which surface the deployment needs.
+
+## Privacy
+
+An authorization claim discloses to every party that receives the token the
+complete enumeration of what the subject holds of that kind, including
+memberships that have nothing to do with the audience the token is aimed at.
+A group name can itself be sensitive, and a resource server needs only the
+groups relevant to its own decisions.
+
+{{search-context}} allows an AS to convey the issuance target so that a PDP
+may scope the result set, but that input is advisory and a PDP may ignore it.
+A deployment for which target scoping is a privacy requirement rather than an
+optimization SHOULD bind claims whose resource type distinguishes the target,
+so that the scoping is expressed where the PDP must honor it, and SHOULD
+consider whether the claim belongs in the token at all.
+
+The searches themselves also disclose to the PDP that a token is being minted
+for a subject, on every issuance and, where the affordance of {{ordering}} is
+taken, on issuances that never complete. {{ISSUANCE}} discusses the
+disclosure of authentication and access patterns to a PDP operated by another
+party; binding claims multiplies the number of requests that disclosure
+travels in, without adding a new category of disclosed information.
+
+# IANA Considerations
+
+This document has no IANA actions. OpenID Foundation registry requests are
+listed in {{oidf-registries}}.
+
+# OpenID Foundation Registry Considerations {#oidf-registries}
+
+## AuthZEN Token Issuance Entity Types Registry {#iana-types}
+
+This specification requests registration of the following entity types in the
+AuthZEN Token Issuance Entity Types registry established by {{ISSUANCE}},
+whose registration policy is Specification Required. Change Controller for all
+entries is the OpenID Foundation AuthZEN Working Group, and the Specification
+Document is this document.
+
+| Type | Applies to | Description |
+|---|---|---|
+| `group` | resource | A group whose members are subjects |
+| `role` | resource | A role assignable to subjects |
+| `entitlement` | resource | An entitlement held by subjects |
+
+## AuthZEN Authorization Claim Bindings Registry {#iana-bindings}
+
+This specification requests creation of a new registry: the AuthZEN
+Authorization Claim Bindings registry, which records for each authorization
+claim the AuthZEN Resource Search that enumerates its members. Registration
+policy is Specification Required.
+
+The registry has the following fields:
+
+| Field | Description |
+|---|---|
+| Claim Name | The JWT claim name being bound |
+| Resource Type | The `resource.type` of the search |
+| Action Name | The `action.name` of the search |
+| Change Controller | The registering specification's change controller |
+| Specification Document(s) | Where the binding is defined |
+
+Registrations MUST use a Claim Name already registered in the "JSON Web Token
+Claims" registry established by {{RFC7519}}, MUST use an Action Name matching
+`[a-z][a-z0-9_]{0,30}`, and MUST use a Resource Type registered in the
+registry of {{iana-types}}. The grammar is the one {{ISSUANCE}} imposes on
+the names it expects to be usable as relation identifiers, and
+{{action-portability-note}} gives the reason it applies here too.
+
+Initial entries:
+
+| Claim Name | Resource Type | Action Name |
+|---|---|---|
+| `groups` | `group` | `member` |
+| `roles` | `role` | `assignee` |
+| `entitlements` | `entitlement` | `holder` |
+
+The Change Controller for all three is the OpenID Foundation AuthZEN Working
+Group and the Specification Document is this document, alongside Section 4.1.2
+of {{RFC7643}} and Section 2.2.3.1 of {{RFC9068}}, which define the claims
+themselves.
+
+### Note on the Action Name Grammar {#action-portability-note}
+
+Action names registered here are bounded by the same grammar {{ISSUANCE}}
+applies to the short names it registers, so that the family keeps one rule
+rather than two.
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+Thanks to the participants in the OpenID AuthZEN interoperability events,
+whose December 2025 identity provider scenario demonstrated AuthZEN search
+operations populating token claims, and to the members of the AuthZEN Working
+Group and the OAuth Working Group.
+
+# Document History
+{:numbered="false"}
+
+Draft 1 continues the individual Internet-Draft
+`draft-gazitt-oauth-authzen-claims`, whose `-01` made the changes below.
+
+## Since -00
+{:numbered="false"}
+
+* Added {{provenance}}, stating that an enriched claim carries no indication
+  of its own provenance and that the instant at which the underlying state
+  held is not establishable from the token.
+* Removed the search context's carve-out for the enforcement point capability
+  declaration, and the declaration itself from the example, neither of which
+  {{ISSUANCE}} defines any longer.

--- a/profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md
+++ b/profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md
@@ -1,0 +1,895 @@
+---
+title: "AuthZEN Binding for OAuth 2.0 Token Exchange - Draft 1"
+abbrev: "AuthZEN Token Exchange Binding"
+category: std
+ipr: none
+
+docname: authzen-oauth-token-exchange-1_0
+workgroup: OpenID AuthZEN
+consensus: true
+v: 3
+stand_alone: true
+smart_quotes: no
+pi: [toc, sortrefs, symrefs, private]
+keyword:
+ - oauth
+ - authorization
+ - authzen
+ - policy
+ - token exchange
+ - delegation
+
+author:
+ -
+    fullname: "Omri Gazitt"
+    organization: "Independent"
+    email: "ogazitt@gmail.com"
+
+normative:
+  RFC6749:
+  RFC8693:
+  RFC8707:
+  AUTHZEN:
+    title: "Authorization API 1.0"
+    target: "https://openid.net/specs/authorization-api-1_0-final.html"
+    date: 2026-01-11
+    author:
+      - ins: "OpenID Foundation AuthZEN Working Group"
+        org: "OpenID Foundation"
+  ISSUANCE: I-D.gazitt-oauth-authzen-issuance
+
+informative:
+  RFC8705:
+  RFC9068:
+  RFC9449:
+  I-D.ietf-oauth-identity-chaining:
+  I-D.ietf-oauth-identity-assertion-authz-grant:
+  I-D.ietf-oauth-transaction-tokens:
+  ZANZIBAR:
+    title: "Zanzibar: Google's Consistent, Global Authorization System"
+    target: "https://www.usenix.org/conference/atc19/presentation/pang"
+    date: 2019
+    author:
+      - ins: R. Pang
+      - ins: R. Caceres
+      - ins: M. Burrows
+
+--- abstract
+
+OAuth 2.0 Token Exchange (RFC 8693) defines the moment at which an
+authorization server decides whether one party may obtain a token to act as,
+or on behalf of, another. It states that the decision is governed by policy,
+and does not define that policy. The specifications layered on top of it -
+identity chaining, identity assertion authorization grants, and transaction
+tokens - inherit the same seam.
+
+This document binds those flows to the AuthZEN profile for OAuth 2.0 token
+issuance. It specifies how a token exchange request is derived into AuthZEN
+evaluation requests, how the authority of the requesting party is expressed
+as a decision distinct from the authority being delegated, and what each of
+the token types layered on token exchange contributes to that mapping.
+
+--- middle
+
+# Introduction
+
+{{RFC8693}} generalizes a family of operations in which a party presents one
+token and asks for another. The specification is precise about the inputs -
+`subject_token`, `actor_token`, `audience`, `resource`, `scope`,
+`requested_token_type` - and about the shape of the result, including the
+`act` claim that records a delegation chain and the `may_act` claim that
+authorizes one party to become the actor for another.
+
+It is deliberately silent about the decision. Section 2.2.1 conditions a
+successful response on the request meeting "all policy and other criteria of
+the authorization server", and defines neither the policy nor the criteria.
+
+{{ISSUANCE}} defines a framework for externalizing that class of decision to
+a Policy Decision Point (PDP) using {{AUTHZEN}}, casting the authorization
+server (AS) as a Policy Enforcement Point. That document is directly
+implementable for grants whose request names a single party and a single
+target. Token exchange names two parties, and several of its members name two
+levels of target; supplying that structure is what this document does. It
+covers:
+
+* token exchange as defined in {{RFC8693}};
+* identity chaining across trust domains
+  ({{I-D.ietf-oauth-identity-chaining}});
+* identity assertion authorization grants
+  ({{I-D.ietf-oauth-identity-assertion-authz-grant}}), referred to here as
+  ID-JAG;
+* transaction tokens ({{I-D.ietf-oauth-transaction-tokens}}), referred to
+  here as Txn-Tokens.
+
+These are treated together because they are one grant with four sets of
+parameters. Each names a subject, a requesting party, a target, and a set of
+privileges, and each arrives at the same undefined decision.
+
+## What This Document Adds
+
+The framework maps a generic issuance request onto AuthZEN's mandatory
+five-tuple. Token exchange adds one structural element the framework does
+not have: **a second party**. Every other issuance flow decides what a
+subject may obtain. A token exchange decides what a *requesting party* may
+obtain *as, or on behalf of,* a subject.
+
+That second party is not decoration. {{RFC8693}} introduces `may_act`
+precisely because the authority to become another party's actor is a
+distinct privilege, and Section 4.4 identifies the party whose authority is
+in question as "the client (or party identified in the `actor_token`)".
+This document's central normative content is that this second privilege is
+evaluated as its own tuple, so that any conforming PDP - including a
+relationship-based engine in the style of {{ZANZIBAR}}, which reads it
+directly as an edge between two named entities - can adjudicate it
+({{actor-gate}}).
+
+The remainder is the derivation of the framework's inputs from each
+specification's parameters, and the small number of invariants that each
+specification places beyond a PDP's reach.
+
+## Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+This document uses the terms of {{RFC6749}}, {{RFC8693}}, {{AUTHZEN}}, and
+{{ISSUANCE}}. In particular, *gate tuple* and *scope tuple* are used as
+defined in {{ISSUANCE}}.
+
+Exchange subject:
+: The party the issued token will represent: the party whose identifier the
+  AS intends to place in the issued token's subject claim. Derived in
+  {{subject}}.
+
+Requesting party:
+: The party asking for the token, on whose own authority the exchange
+  depends. This is the party identified by `actor_token` where one is
+  present, and the authenticated client otherwise. Derived in
+  {{requesting-party}}.
+
+Issuance target:
+: As in {{ISSUANCE}}: the audience of the access being granted.
+
+# Applicability
+
+This binding applies to a request at the token endpoint whose `grant_type`
+is `urn:ietf:params:oauth:grant-type:token-exchange`, and to the assertion
+grants used to redeem an ID-JAG ({{id-jag}}).
+
+The AS performs the evaluation described here only after it has completed
+every validation the underlying specification requires: authenticating the
+client, validating the `subject_token` and any `actor_token` and confirming
+their issuers are trusted, and verifying any proof of possession. A permit
+from a PDP does not substitute for any of these. This restates
+{{ISSUANCE}}'s architecture and is repeated because token exchange is the
+flow in which the temptation to conflate the two is greatest: the PDP is
+being asked whether a delegation is *permitted*, never whether the presented
+tokens are *valid*.
+
+# Forming the Evaluation Request
+
+## Subject {#subject}
+
+The exchange subject is derived from `subject_token`, interpreted according
+to `subject_token_type`:
+
+| Value of subject_token_type | Exchange subject |
+|---|---|
+| `access_token`, `id_token`, `jwt` | The subject of the presented token |
+| `refresh_token` | The subject the refresh token was issued for |
+| `saml1`, `saml2` | The subject of the assertion |
+| `self_signed`, `unsigned_json` | See {{txn-tokens}} |
+
+`subject.type` MUST be `user` where the exchange subject is a natural person
+and `workload` where it is a non-human software identity, per the registry
+established by {{ISSUANCE}}.
+
+`subject.id` MUST be the identifier the AS intends to place in the issued
+token's subject claim, as {{ISSUANCE}} requires. In token exchange this
+ordering constraint has teeth, because the subject identifier frequently
+changes during the exchange: an AS receiving a token from a peer trust
+domain resolves the foreign subject to a local account, and an AS issuing
+pairwise identifiers computes one per audience. Any such resolution MUST be
+performed **before** the evaluation request is constructed.
+
+An AS that evaluated against the incoming identifier and then issued a token
+bearing a resolved one would obtain a decision about a subject that does not
+appear in the token it mints.
+
+## Requesting Party {#requesting-party}
+
+The requesting party is:
+
+1. the party identified by `actor_token`, interpreted according to
+   `actor_token_type`, where an `actor_token` is present; otherwise
+2. the authenticated client.
+
+`subject.type` for the requesting party MUST be `client` where it is an
+OAuth client identified by a client identifier, and `workload` where it is a
+software identity presenting a credential such as an X.509 certificate
+({{RFC8705}}) or a workload identity document.
+
+The requesting party is derived in both delegation and impersonation. It is
+in the impersonation case - where the issued token carries no `act` claim
+and the requesting party is therefore invisible in the result - that
+evaluating its authority matters most, because nothing downstream can
+recover it.
+
+## Actions {#actions}
+
+A token exchange request produces gate tuples and scope tuples as defined in
+{{ISSUANCE}}, which requires a gate tuple on every request. This binding
+produces **two**, because a token exchange has two parties whose authority
+is in question.
+
+Both carry the same `action.name`, of the form
+`issue:<token-type>:token_exchange`, where the token type short name is the
+one registered for the value of `requested_token_type` ({{iana-actions}}).
+The grant segment is `token_exchange` throughout, since that is the grant
+this binding applies to; it is what distinguishes these tuples from those a
+direct request by the same party for the same target would produce.
+
+Where `requested_token_type` is absent, {{RFC8693}} directs the AS to its
+default, and the short name for that default type is used.
+
+### Subject Gate Tuple
+
+The AS MUST include a gate tuple whose subject is the exchange subject.
+
+### Requesting Party Gate Tuple {#actor-gate}
+
+The AS MUST include a second gate tuple whose subject is the requesting
+party ({{requesting-party}}), with the same `action.name` and the same
+resource as the subject gate tuple.
+
+This tuple is the interoperable expression of the question {{RFC8693}}
+Section 4.4 poses: whether the client, or the party named in the
+`actor_token`, is authorized to engage in the requested delegation or
+impersonation. Expressing it as a five-tuple rather than as a property of
+the subject's tuple is what puts it within reach of any conforming PDP: a
+relationship-based engine adjudicates it directly, as the relation between a
+named subject and a named object, without having to be told how to project a
+property bag into one.
+
+The two gate tuples ask different questions and both MUST be permitted:
+
+* the subject gate asks whether a token of this kind may exist for this
+  subject and this target at all;
+* the requesting party gate asks whether this party may be the one to obtain
+  it.
+
+Where the requesting party and the exchange subject are the same entity -
+a client exchanging a token it obtained for itself - the two gate tuples are
+identical, and the AS MAY include only one.
+
+### `may_act` Is Not a Substitute
+
+Where the `subject_token` carries a `may_act` claim, the AS MUST convey it
+as advisory context ({{context}}) and MUST NOT treat its presence as
+satisfying the requesting party gate tuple, nor its absence as denying it.
+
+`may_act` is an assertion made by the issuer of the subject token at the
+time that token was minted. The gate tuple is a decision rendered by policy
+at the time of the exchange. Substituting the first for the second would
+reintroduce, one layer down, exactly the staleness that consulting a PDP at
+issuance exists to address. An ABAC-class PDP is free to consume `may_act`
+from context and require the requesting party to appear in it; that is a
+policy choice made at the PDP, which is where it belongs.
+
+### Scope Tuples
+
+Scope tuples are formed as in {{ISSUANCE}}, one per requested scope value,
+carried verbatim.
+
+The subject of every scope tuple MUST be the exchange subject, not the
+requesting party. Scope expresses access authority, and in both delegation
+and impersonation the access being exercised is the subject's. A requesting
+party cannot acquire access the subject does not have by asking for it on
+the subject's behalf; its own privilege is the right to act as the subject
+at all, which the gate tuple decides.
+
+{{txn-tokens}} defines an additional requirement for Txn-Tokens, whose
+governing specification makes the requesting workload's authority
+scope-dependent.
+
+## Resource {#resource}
+
+`resource.type` MUST be `audience` and `resource.id` MUST be the issuance
+target, as in {{ISSUANCE}}. Where the request carries an `audience`
+parameter, or a `resource` parameter in the sense of {{RFC8707}}, that value
+determines the issuance target.
+
+Where the request names more than one target, the AS MUST fan the tuples out
+across targets: each gate tuple and each scope tuple is evaluated once per
+named target.
+
+### Two-Level Evaluation for Chained Grants {#two-level}
+
+Some members of this family issue an artifact that is consumed by one party
+in order to obtain access at another. An ID-JAG is presented to a peer
+authorization server, but the access it describes is at a resource behind
+that server. The artifact's own audience and the audience of the access
+being granted are different values, and both are decision-critical: the
+first governs delegation into a trust domain, the second governs reach
+within it.
+
+Where the two differ, the AS MUST perform a **two-level evaluation**,
+producing tuples at both:
+
+* **Level 1**, with `resource.id` set to the consumer of the issued artifact
+  - the peer authorization server. Gate tuples appear only at this level.
+* **Level 2**, with `resource.id` set to each resource identifier named by
+  the request under {{RFC8707}}. Scope tuples are produced at both levels,
+  and authorization detail tuples only here: an entry describes access at a
+  resource rather than delegation to the consumer of the artifact. Where an
+  entry omits `locations`, the targets {{ISSUANCE}} substitutes are the
+  level-2 resources.
+
+A denial at level 1 is a refusal to delegate into that trust domain and is
+fatal.
+
+A denial at level 2 narrows what the issued artifact may name, and how
+depends on which tuple was denied. A denied scope tuple removes that scope
+from the artifact entirely, even where other level-2 resources permitted it,
+which is the intersection {{ISSUANCE}} requires. A denied authorization
+detail cell narrows only its own entry at its own location, because a cell
+names the location it applies to.
+
+The intersection is forced here by redemption rather than by {{RFC9068}}. An
+ID-JAG carries the level-2 resources in a `resource` claim and its scopes in
+a flat `scope` claim, with no pairing between them, and
+{{I-D.ietf-oauth-identity-assertion-authz-grant}} has the resource
+authorization server process both and grant any subset it decides on. A
+scope the identity provider's PDP permitted at one resource and denied at
+another would therefore reach redemption with the denial no longer visible,
+and could be granted for the resource that denied it. An AS whose deployment
+needs a scope to survive at one level-2 resource and not another issues one
+ID-JAG per resource, or expresses the distinction in
+`authorization_details`, where the location is part of the cell.
+
+Where the request names no {{RFC8707}} resource, level 2 does not exist and
+the evaluation is single-level.
+
+## Context {#context}
+
+In addition to the keys defined by {{ISSUANCE}}, an AS implementing this
+binding SHOULD convey the following in the request `context`. All are
+advisory: a PDP MUST be able to render a decision from the five-tuple alone.
+
+| Key | Type | Value |
+|---|---|---|
+| `subject_token_type` | string | The `subject_token_type` parameter, verbatim |
+| `actor_token_type` | string | The `actor_token_type` parameter, if present |
+| `subject_token` | object | Selected validated claims of the subject token, such as `iss`, `acr`, `amr`, and `auth_time` |
+| `act` | object | The `act` claim of the subject token, if present, conveying an existing delegation chain |
+| `may_act` | object | The `may_act` claim of the subject token, if present |
+| `cnf` | object | The confirmation method of the presented credential, where the exchange is sender-constrained under {{RFC8705}} or {{RFC9449}} |
+
+Each key has one JSON type, as {{ISSUANCE}} requires of context keys defined
+by a binding.
+
+`requested_token_type` is not among them. It determines the token type
+segment of the gate action name, so it is already in the five-tuple, and
+repeating it in `context` would give a PDP two places to read the same fact
+and a way for them to disagree. `subject_token_type` and `actor_token_type`
+describe the credentials presented, not the token requested, and remain
+advisory.
+
+An AS MUST NOT place raw token strings in `context`. Only claims the AS has
+already validated are conveyed, and only those a deployment's policies
+consume. The subject token may carry claims about a party that has not
+authorized their disclosure to the PDP.
+
+## Batch Composition {#composition}
+
+Except where a request names no scopes and the two gate tuples coincide
+({{actor-gate}}), the AS uses the Access Evaluations API of {{AUTHZEN}} as
+{{ISSUANCE}} specifies, with `options.evaluations_semantic` set to
+`execute_all`.
+
+{{ISSUANCE}} requires gate tuples to occupy the leading indices of the
+`evaluations` array. Here that ordinarily means indices 0 and 1, in the order
+given in {{actions}}: the subject gate first, then the requesting party gate.
+Scope tuples follow. The AS MUST fail the request without issuing a token if
+either gate is denied.
+
+Narrowing is the ordinary outcome of a scope denial, and matches
+{{I-D.ietf-oauth-identity-assertion-authz-grant}}, which states that granted
+scopes may be a subset of those requested. Where a deployment instead intends
+the requested privileges to be granted whole, it does not vary the evaluations
+semantic to obtain that: it fails the request when any scope tuple is denied.
+
+A short-circuiting semantic is not used, because it may return a truncated
+`evaluations` array while the aggregation rules of {{ISSUANCE}} are defined
+over the complete set of per-item results. Composing those results is the AS's
+work here in any case: {{AUTHZEN}} selects the semantic per request rather
+than per item, so the fatality of a gate denial is enforced by the AS and not
+by the PDP. Retaining every per-item result also preserves the record of which
+privilege was refused, which is what an operator needs when a request fails.
+
+# Token Type Bindings
+
+## Access Tokens and Refresh Tokens
+
+No additional derivation is required. The mapping of {{ISSUANCE}} and the
+preceding sections is complete for an exchange whose
+`requested_token_type` is `urn:ietf:params:oauth:token-type:access_token` or
+`urn:ietf:params:oauth:token-type:refresh_token`.
+
+## Identity Chaining
+
+{{I-D.ietf-oauth-identity-chaining}} composes two token endpoint requests:
+an exchange at the authorization server of trust domain A yielding an
+authorization grant for trust domain B, and the redemption of that grant at
+B's authorization server.
+
+Each leg is an independent issuance decision and is evaluated independently,
+against the PDP of the trust domain whose authorization server is
+performing it. Neither AS relies on the other's evaluation. This follows
+from the specification's own model, in which each domain remains
+authoritative for its own policy, and it is what the profile is for: the
+first leg decides whether authority may leave domain A, the second decides
+what authority it acquires in domain B.
+
+The first leg is a two-level evaluation under {{two-level}} where the
+request names {{RFC8707}} resources. The second leg is an ordinary
+single-level evaluation whose exchange subject is the local account the
+foreign subject resolved to, per {{subject}}.
+
+{{I-D.ietf-oauth-identity-chaining}} notes that a request may be denied due
+to policy, for instance where a trust relationship is not established. Under
+this binding, the existence of the trust relationship remains a
+precondition the AS validates; the PDP decides what is permitted across a
+relationship that already exists.
+
+## Identity Assertion Authorization Grant {#id-jag}
+
+An ID-JAG is issued by an identity provider's authorization server and
+redeemed at an application's authorization server.
+
+**Issuance.** The `requested_token_type` is
+`urn:ietf:params:oauth:token-type:id-jag`, so the gate tuples carry
+`action.name` of `issue:id_jag:token_exchange`. The issued grant's audience
+is the
+resource authorization server, while
+{{I-D.ietf-oauth-identity-assertion-authz-grant}} makes the {{RFC8707}}
+`resource` subset a policy decision in its own right. The AS MUST therefore
+perform a two-level evaluation under {{two-level}}.
+
+`scope` is OPTIONAL in an ID-JAG request. Where it is absent, the request
+produces gate tuples and no scope tuples, and a PDP that wishes to grant a
+specific set returns `granted_scope` in the response context, as
+{{ISSUANCE}} defines. This is the case the framework's gate tuple exists
+for: without it, a scopeless ID-JAG request would produce no evaluation at
+all.
+
+{{I-D.ietf-oauth-identity-assertion-authz-grant}} has the identity provider
+evaluate policy for each requested authorization detail, and permits it to
+modify, filter, or omit them. Under this binding the unit is finer than the
+entry, since {{ISSUANCE}} decomposes each entry into one tuple per cell, and
+the three operations have distinct sources. An entry is omitted where every
+one of its cells is denied. An entry is filtered where only some are, which
+may require returning it as several entries of one `type` rather than one.
+Modification beyond what the cells can express comes from the
+`authorization_details` shaping key of {{ISSUANCE}}, subject to that key's
+structural check.
+
+**Redemption.** The application's authorization server presents the ID-JAG
+as an assertion grant. This is an ordinary single-level evaluation. Its
+exchange subject is the local account produced by the subject resolution
+that {{I-D.ietf-oauth-identity-assertion-authz-grant}} requires, and its
+requesting party is the client authenticated at that endpoint - which is a
+different party from the client that obtained the grant. Evaluating it is
+the point: redemption is where an application's own authorization server
+decides what the asserted identity may do locally.
+
+Where a deployment is multi-tenant, the AS SHOULD convey the tenant
+identifier in `context`. A deployment whose decisions genuinely depend on
+tenancy SHOULD instead encode the tenant in `resource.id`, so that the
+dependency is visible in the five-tuple.
+
+## Transaction Tokens {#txn-tokens}
+
+{{I-D.ietf-oauth-transaction-tokens}} defines a Transaction Token Service
+(TTS) that mints short-lived tokens carrying a call chain's originating
+context. Its issuance decision is the one this profile addresses, and the
+specification states directly that the authorization policy determining
+issuance is out of scope for it.
+
+Txn-Tokens differ from the rest of the family in four ways that the binding
+must account for.
+
+**There is no `actor_token`.** The requesting party is the workload that
+authenticated to the TTS, typically with a credential under {{RFC8705}} or
+a workload identity document. It is derived under rule 2 of
+{{requesting-party}} with `subject.type` of `workload`.
+
+**The requesting workload's authority is scope-dependent.** The
+specification requires the TTS to determine whether the requesting workload
+is authorized to obtain a Txn-Token *with the requested values*, not merely
+whether it may obtain one. For `requested_token_type` of
+`urn:ietf:params:oauth:token-type:txn_token`, the AS MUST therefore include
+scope tuples for the requesting party in addition to those for the exchange
+subject. Both sets MUST be permitted for the corresponding scope to be
+granted. This is the one place in this document where the requesting party
+is evaluated for access authority rather than only for issuance authority,
+and it is required because the governing specification asks for it.
+
+**Subject derivation is ambiguous for self-signed and unsigned subject
+tokens.** Where `subject_token_type` is
+`urn:ietf:params:oauth:token-type:self_signed` or
+`urn:ietf:params:oauth:token-type:unsigned_json`, the presented token is not
+an authority on identity. The AS MUST determine whether the request is on
+behalf of a user, in which case the exchange subject is that user and the
+AS MUST have an independent basis for believing the assertion, or on the
+workload's own behalf, in which case the exchange subject is the requesting
+workload itself and the two gate tuples coincide. An AS MUST NOT accept a
+user identity from an unsigned subject token without such a basis. The PDP
+cannot detect this error, because it sees only the identifier it is given.
+
+**Transaction context may originate at the PDP.** The specification makes
+the TTS authoritative for the transaction context of the token it mints, and
+permits that context to be derived from the request details. A PDP is a
+legitimate source for that derivation. Where a deployment uses one, the
+transaction context is carried as a member of the `claims` shaping key of
+{{ISSUANCE}}, and the TTS remains authoritative: it MUST validate the
+returned value before minting, and its own determination prevails.
+
+A PDP that asserts a quantitative ceiling in transaction context is
+asserting a constraint that a downstream enforcement point is expected to
+apply, and dropping it would broaden what the token effectively authorizes.
+A PDP asserting such a value MUST name the claim in `crit`, per {{ISSUANCE}}.
+
+Requests for replacement Txn-Tokens are a second issuance moment with the
+same tuple shape and require no additional machinery. The invariants that
+{{I-D.ietf-oauth-transaction-tokens}} places on a replacement - that it MUST
+NOT expand scope, and MUST NOT modify the transaction identifier, subject,
+or audience - are preconditions the TTS enforces. **A PDP cannot waive
+them.** A permit authorizes a replacement within those bounds; it does not
+authorize one outside them.
+
+# Processing the Response
+
+The response processing rules of {{ISSUANCE}} apply without change,
+including the no-broadening rule, the mandatory-to-understand
+classification, the reserved claim list, and the aggregation rules for
+composing per-item shaping across a batch.
+
+Two consequences of that framework are worth restating here, because token
+exchange is where they bind hardest.
+
+**`sub` and `aud` are reserved.** A PDP cannot rewrite the subject or the
+audience of the issued token. In a family of flows whose entire purpose is
+to produce a token for a different audience, or bearing a different subject
+identifier, than the one presented, the temptation to let the PDP perform
+that transformation is real. It must be resisted: re-subjecting a token is a
+fresh issuance rather than an attenuation of an existing one, and must be
+evaluated as such. The AS decides the transformation and evaluates the
+result, as {{subject}} requires.
+
+**`act` and `may_act` are reserved.** The delegation chain of the issued
+token is constructed by the AS from parties it authenticated. A PDP that
+could write `act` could fabricate a delegation history; a PDP that could
+write `may_act` could confer delegation authority that no evaluation
+considered, which is broadening by construction.
+
+# Error Mapping
+
+The mapping of {{ISSUANCE}} applies, refined for the errors of {{RFC8693}}:
+
+| Condition | Authorization server behavior |
+|---|---|
+| Subject gate tuple denied | Fail; `invalid_request` |
+| Requesting party gate tuple denied | Fail; `invalid_request` |
+| All scope tuples denied | Fail; `invalid_scope` |
+| Some scope tuples denied | Issue with the permitted subset; report via `scope` |
+| Level 1 denied in a two-level evaluation | Fail; `invalid_target` |
+| Every target denied, or shaping empties the target set | Fail; `invalid_target` |
+| Requested token type not permitted | Fail; `invalid_request` |
+| PDP unreachable or response malformed | Fail closed; do not issue |
+
+An AS MUST NOT distinguish, in the error returned to the client, between a
+denial of the subject gate and a denial of the requesting party gate. The
+difference tells the requesting party whether its own authority or the
+subject's was lacking, which is information about the subject's authority
+that the requesting party has not been authorized to learn. Both are
+reported as `invalid_request`, and the distinction is recorded where
+{{ISSUANCE}} directs PDP reason information: in the AS's own logs.
+
+# Discovery
+
+This binding registers no capability URN of its own. A PDP advertises support
+for the URN of {{ISSUANCE}}, and nothing further is negotiated.
+
+Nothing further is needed. A capability URN identifies response vocabulary,
+because an AS must understand what it is asked to enforce, and this binding
+adds none: it uses the shaping keys of {{ISSUANCE}} unchanged. The context
+keys of {{context}} are advisory, and a PDP that does not recognize one
+ignores it. The gate action names registered in {{iana-actions}} are covered
+by {{ISSUANCE}}'s rule that a PDP advertising the issuance capability renders
+a decision on any registered gate action, so an AS never has to discover
+which members of this family a deployment's policy anticipates.
+
+An operator enabling one of these grants for the first time - ID-JAG on an AS
+that previously performed only ordinary exchanges, say - can check whether
+policy anticipates the new gate action before turning it on, using the Action
+Search API of {{AUTHZEN}} as {{ISSUANCE}} describes.
+
+# Examples
+
+The first example below is shown in full, framed against the HTTPS JSON
+binding of {{AUTHZEN}}; the second shows only the JSON payload. As
+{{ISSUANCE}} notes, the transport is a property of the deployment, and where
+the HTTPS JSON binding is in use the request URL is the PDP's
+`access_evaluations_endpoint` where its metadata publishes one. Both requests
+here carry two gate tuples, so neither reduces to a single evaluation.
+
+## Delegation With an Actor Token
+
+A gateway workload exchanges a user's access token for a token aimed at a
+partner API, acting on the user's behalf. Two gate tuples and one scope
+tuple result.
+
+~~~ http-message
+POST /token HTTP/1.1
+Host: as.example
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token=eyJ...
+&subject_token_type=urn:ietf:params:oauth:token-type:access_token
+&actor_token=eyJ...
+&actor_token_type=urn:ietf:params:oauth:token-type:jwt
+&requested_token_type=urn:ietf:params:oauth:token-type:access_token
+&audience=https%3A%2F%2Fapi.partner.example
+&scope=read%3Adocs
+~~~
+
+~~~ http-message
+POST /access/v1/evaluations HTTP/1.1
+Host: pdp.example.com
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "resource": {
+    "type": "audience",
+    "id": "https://api.partner.example"
+  },
+  "context": {
+    "client_id": "gateway-client",
+    "may_act": { "sub": "spiffe://cluster/ns/prod/sa/gateway" }
+  },
+  "evaluations": [
+    {
+      "subject": { "type": "user", "id": "alice@example.com" },
+      "action":  {
+        "name": "issue:access_token:token_exchange"
+      }
+    },
+    {
+      "subject": {
+        "type": "workload",
+        "id": "spiffe://cluster/ns/prod/sa/gateway"
+      },
+      "action":  {
+        "name": "issue:access_token:token_exchange"
+      }
+    },
+    {
+      "subject": { "type": "user", "id": "alice@example.com" },
+      "action":  { "name": "read:docs" }
+    }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+A relationship-based PDP reads the second tuple as an edge between
+`workload:spiffe://cluster/ns/prod/sa/gateway` and
+`audience:https://api.partner.example` under the relation
+`issue_access_token_token_exchange`. No property bag is consulted, and the
+relation is distinct from the one that would govern the gateway obtaining a
+token for itself under the client credentials grant.
+
+~~~ http-message
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "evaluations": [
+    { "decision": true },
+    { "decision": true },
+    {
+      "decision": true,
+      "context": {
+        "issuance": {
+          "token_lifetime": 300,
+          "claims": { "groups": ["eng", "sre"] }
+        }
+      }
+    }
+  ]
+}
+~~~
+
+The AS issues an access token for `https://api.partner.example` bearing
+`scope` of `read:docs`, an `act` claim naming the gateway, a `groups` claim,
+and a lifetime no greater than 300 seconds.
+
+## Scopeless ID-JAG, Two Levels
+
+An ID-JAG request naming a resource but no scopes. Two gate tuples at level
+1, no scope tuples anywhere, and the PDP supplies the grantable set.
+
+~~~ json
+{
+  "context": { "client_id": "chatterbox-idp-7f3a" },
+  "evaluations": [
+    {
+      "subject":  { "type": "user", "id": "U0405936" },
+      "action":   { "name": "issue:id_jag:token_exchange" },
+      "resource": {
+        "type": "audience",
+        "id": "https://as.app.example"
+      }
+    },
+    {
+      "subject":  { "type": "client", "id": "chatterbox-idp-7f3a" },
+      "action":   { "name": "issue:id_jag:token_exchange" },
+      "resource": {
+        "type": "audience",
+        "id": "https://as.app.example"
+      }
+    }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+~~~ json
+{
+  "evaluations": [
+    {
+      "decision": true,
+      "context": {
+        "issuance": {
+          "granted_scope": "files.read",
+          "token_lifetime": 300
+        }
+      }
+    },
+    { "decision": true }
+  ]
+}
+~~~
+
+The AS mints an ID-JAG naming `files.read` and the requested resource. Had
+the PDP returned a bare permit, the AS would have fallen back to its own
+default scope set for that client and target, which is a safe degradation:
+a PDP unable to enumerate a grantable set is not thereby able to broaden
+one.
+
+# Security Considerations
+
+The considerations of {{ISSUANCE}} apply in full, including fail-closed
+behavior, the treatment of the PDP as a trust dependency, and the privacy
+consequences of consulting a PDP on every issuance.
+
+## Impersonation Is the Dangerous Case
+
+An impersonation exchange produces a token indistinguishable from one issued
+to the subject directly. Nothing downstream can determine that a different
+party obtained it, which means no downstream enforcement point can apply
+policy to the requesting party's involvement. The requesting party gate
+tuple of {{actor-gate}} is the only point at which that party's authority is
+evaluated at all.
+
+An implementation that omitted it - reasoning that the client was already
+authenticated, or that `may_act` was present in the subject token - would
+externalize the delegation decision in name only. Client authentication
+establishes who is asking; it does not establish that they may ask for this.
+
+## Chain Depth and Repeated Exchange
+
+A token obtained by exchange may itself be exchanged. Each exchange is an
+independent decision under this binding, so authority cannot be broadened by
+iteration: every step is gated, and the scope tuples at each step are
+bounded by what the AS would otherwise grant.
+
+What repetition can accumulate is *lifetime*. A chain of exchanges, each
+issuing a token whose lifetime is permitted at that moment, can keep
+authority alive well past the point at which the original grant would have
+expired. Deployments SHOULD convey the existing `act` chain in context so
+that policy can act on chain depth, and SHOULD bound the lifetime of an
+exchanged token by the remaining lifetime of the subject token. The second
+is an AS responsibility: a `token_lifetime` shaping value is a ceiling and
+never a floor, so a PDP cannot repair an AS that fails to apply it.
+
+## Trust in the Subject Token Issuer
+
+In cross-domain flows the subject token is issued by a party in another
+trust domain, and the claims conveyed to the PDP as context originate there.
+A PDP whose policy depends on those claims has extended trust to that
+issuer. This is a further reason for the five-tuple rule: a decision that
+depends only on the resolved local subject identifier, the requesting party,
+the action, and the target depends on values the local AS established
+itself.
+
+## Denial Information Disclosure
+
+Both the error mapping above and {{ISSUANCE}}'s prohibition on relaying PDP
+reason strings exist to keep the requesting party from learning the shape of
+a policy that governs a subject it is merely acting for. Deployments adding
+diagnostics to token endpoint error responses should preserve this.
+
+# IANA Considerations
+
+This document has no IANA actions. OpenID Foundation registry requests are
+listed in {{oidf-registries}}.
+
+# OpenID Foundation Registry Considerations {#oidf-registries}
+
+## AuthZEN Token Issuance Action Names Registry {#iana-actions}
+
+This specification requests registration of the following token type short
+names in the AuthZEN Token Issuance Action Names registry established by
+{{ISSUANCE}}, whose registration policy is Specification Required. Change
+Controller for all entries is the OpenID Foundation AuthZEN Working Group,
+and the Specification Document is this document.
+
+| Short name | Token type |
+|---|---|
+| `id_jag` | `urn:ietf:params:oauth:token-type:id-jag` |
+| `txn_token` | `urn:ietf:params:oauth:token-type:txn_token` |
+| `jwt` | `urn:ietf:params:oauth:token-type:jwt` |
+| `saml1` | `urn:ietf:params:oauth:token-type:saml1` |
+| `saml2` | `urn:ietf:params:oauth:token-type:saml2` |
+
+The short names for `access_token`, `refresh_token`, and `id_token`, and the
+`token_exchange` grant type short name that pairs with all of the above, are
+registered by {{ISSUANCE}}.
+
+`id_jag` uses an underscore where the token type URI uses a hyphen, as
+{{ISSUANCE}} requires of every registered short name.
+
+> **Editor's note.** These registrations depend on the corresponding token
+> types being registered in the "OAuth URI" registry by their own
+> specifications. `id-jag` and `txn_token` are requested by documents still
+> in progress, and the short names above should be confirmed against the
+> values those documents ultimately register.
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+The separation of issuance authority from access authority, which this
+document expresses as two gate tuples, was arrived at by working through the
+protocol messages of {{I-D.ietf-oauth-identity-assertion-authz-grant}} and
+{{I-D.ietf-oauth-transaction-tokens}}, and the resulting shape owes a great
+deal to the care with which those documents model their inputs.
+
+Thanks to the members of the OAuth Working Group and the OpenID AuthZEN
+Working Group.
+
+# Document History
+{:numbered="false"}
+
+Draft 1 continues the individual Internet-Draft
+`draft-gazitt-oauth-authzen-token-exchange`, whose `-01` made the changes
+below.
+
+## Since -00
+{:numbered="false"}
+
+* Authorization details are narrowed by the cell rather than by the scope
+  tuple, following the authorization detail tuple {{ISSUANCE}} now defines.
+* {{two-level}} places authorization detail tuples at level 2 and says which
+  targets are substituted for an entry that omits `locations`.
+* A denied scope tuple at level 2 and a denied authorization detail cell at
+  level 2 narrow different things, and the scope intersection is justified by
+  what an ID-JAG loses at redemption rather than by {{RFC9068}}.
+* Removed the enforcement point capability declaration from the examples,
+  which {{ISSUANCE}} no longer defines.

--- a/profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md
+++ b/profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md
@@ -1,0 +1,1810 @@
+---
+title: "AuthZEN Profile for OAuth 2.0 Token Issuance - Draft 1"
+abbrev: "AuthZEN Token Issuance"
+category: std
+ipr: none
+
+docname: authzen-oauth-token-issuance-1_0
+workgroup: OpenID AuthZEN
+consensus: true
+v: 3
+stand_alone: true
+smart_quotes: no
+pi: [toc, sortrefs, symrefs, private]
+keyword:
+ - oauth
+ - authorization
+ - authzen
+ - policy
+ - token exchange
+
+author:
+ -
+    fullname: "Omri Gazitt"
+    organization: "Independent"
+    email: "ogazitt@gmail.com"
+
+normative:
+  RFC6749:
+  RFC7519:
+  RFC8693:
+  RFC9396:
+  AUTHZEN:
+    title: "Authorization API 1.0"
+    target: "https://openid.net/specs/authorization-api-1_0-final.html"
+    date: 2026-01-11
+    author:
+      - ins: "OpenID Foundation AuthZEN Working Group"
+        org: "OpenID Foundation"
+
+informative:
+  RFC7515:
+  RFC7643:
+  RFC8176:
+  RFC8707:
+  RFC9068:
+  RFC9126:
+  RFC9470:
+  RFC9700:
+  I-D.brossard-oauth-rar-authzen:
+  I-D.gerber-oauth-deferred-token-response:
+  I-D.ietf-oauth-identity-chaining:
+  I-D.ietf-oauth-identity-assertion-authz-grant:
+  I-D.ietf-oauth-transaction-tokens:
+  ARAP:
+    title: "AuthZEN Access Request and Approval Profile 1.0"
+    target: "https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0"
+    date: 2026-07-27
+    author:
+      - ins: K. McGuinness
+        name: "Karl McGuinness"
+        org: "Independent"
+  GRANTMGMT:
+    title: "Grant Management for OAuth 2.0"
+    target: "https://openid.bitbucket.io/fapi/oauth-v2-grant-management.html"
+    date: 2026-06-26
+    author:
+      - ins: T. Lodderstedt
+        name: "Torsten Lodderstedt"
+        org: "yes.com"
+      - ins: S. Low
+        name: "Stuart Low"
+        org: "Biza.io"
+      - ins: D. Postnikov
+        name: "Dima Postnikov"
+        org: "Independent"
+  ZANZIBAR:
+    title: "Zanzibar: Google's Consistent, Global Authorization System"
+    target: "https://www.usenix.org/conference/atc19/presentation/pang"
+    date: 2019
+    author:
+      - ins: R. Pang
+      - ins: R. Caceres
+      - ins: M. Burrows
+
+--- abstract
+
+Numerous OAuth 2.0 specifications define a moment at which an authorization
+server decides whether to issue a security token, and each of them declares
+the decision itself to be a matter of local policy that is out of scope.
+The result is that a decision common to every OAuth deployment has no
+interoperable expression.
+
+This document defines a profile for using the OpenID AuthZEN Authorization
+API to externalize that decision to a Policy Decision Point. It specifies
+how the inputs to a token issuance request map onto AuthZEN's mandatory
+five-tuple, how a Policy Decision Point response may shape the issued token,
+and how a Policy Decision Point advertises support for the profile.
+
+The mapping is complete for grants whose request names a single party,
+including the authorization code and client credentials grants. Companion
+documents bind the grant families that add structure this document does not
+model, the token exchange family first among them.
+
+--- middle
+
+# Introduction
+
+Consider the moment an OAuth 2.0 authorization server (AS) has authenticated
+a client, validated a grant, and must decide whether to mint a token - and
+if so, with what scopes, what audience, what lifetime, and what claims.
+Every specification that defines such a moment models its inputs in careful
+detail and then stops short of the decision.
+
+{{RFC8693}}, which defines OAuth 2.0 Token Exchange, is explicit that the
+decision to issue is governed by policy it does not define. The
+specifications built on top of it inherit that seam: identity chaining
+({{I-D.ietf-oauth-identity-chaining}}), identity assertion authorization
+grants ({{I-D.ietf-oauth-identity-assertion-authz-grant}}), and transaction
+tokens ({{I-D.ietf-oauth-transaction-tokens}}) each describe an
+"administrator-defined policy" or equivalent without describing how such a
+policy is expressed, evaluated, or externalized.
+
+Leaving the decision to local policy is the correct choice for those
+documents. But it means that the single most security-relevant step in token
+issuance is, today, an implementation detail - expressed in vendor-specific
+rules engines, inline hooks, and scripting extensions that do not port
+between authorization servers and cannot be reasoned about by anything
+outside the AS.
+
+{{AUTHZEN}} defines an interoperable API between a Policy Enforcement Point
+(PEP) and a Policy Decision Point (PDP). This document profiles that API for
+the token issuance moment, casting the **authorization server as a PEP**.
+
+## Design Goals {#design-goals}
+
+**One mechanism, many issuance moments.** The decision point is
+structurally identical across grant types: a party is asking for a token,
+naming a target and some set of privileges. This document defines that
+mapping once. Bindings ({{companions}}) supply what is specific to a given
+grant or token type, and are expected to be short.
+
+**Interoperability at the level of policy, not just wire format.**
+{{AUTHZEN}} makes exactly five fields mandatory in an evaluation request:
+`subject.type`, `subject.id`, `action.name`, `resource.type`, and
+`resource.id`. Everything else - the `properties` bag on each entity, and the
+`context` object - is optional. That asymmetry is deliberate. It is what
+allows one request shape to be understood by policy engines with very
+different internal models: attribute- and policy-based engines that evaluate
+expressions over arbitrary input, and relationship-based engines in the style
+of {{ZANZIBAR}} that reason over a typed graph of subjects, relations, and
+objects.
+
+This is not a claim that a relationship-based engine can consume nothing
+beyond the five-tuple. Such engines commonly accept contextual tuples
+supplied at query time, and a PDP may project `properties` or `context` into
+them. It is a claim about where a profile should put the load. The five-tuple
+has a shape every conforming PDP can be expected to read the same way; a
+free-form bag does not, and a profile that carried its decision-critical
+inputs there would nominally use AuthZEN while leaving each PDP to infer the
+semantics on its own.
+
+This document therefore adopts a design rule:
+
+> The five-tuple is the primary information model target. Every input on
+> which the decision depends MUST be expressed in it. `properties` and
+> `context` carry advisory input only, and a conforming mapping MUST be
+> implementable by a PDP that reads only the five-tuple.
+
+The rule is applied throughout and is not re-argued at each mapping.
+
+**Least surprise for the AS.** The profile does not ask the AS to surrender
+decisions it is authoritative for. A PDP may narrow what is issued; it may
+not broaden it, re-subject it, or re-target it ({{no-broadening}}).
+
+## Scope
+
+This document covers **token issuance**: the decision made by an
+authorization server at its token endpoint, before a token is minted. It
+does not address enforcement at a resource server, which is the ordinary
+case AuthZEN already serves and requires no profile.
+
+The framework decides an **issuance gate**. Where a deployment's policy
+depends on quantitative or transactional constraints - a payment amount, a
+rate limit - those flow in as advisory context and out as token shaping
+({{shaping}}), to be enforced by downstream policy enforcement points. Any
+conforming PDP can adjudicate the gate, because the gate is expressed
+entirely in the five-tuple. Whether a given PDP also adjudicates the context
+is a property of that deployment and is not something this profile
+guarantees. Stating that boundary is what keeps the design rule above from
+overpromising.
+
+## Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+This document uses the terms Authorization Server, Client, Resource Server,
+access token, and scope from {{RFC6749}}; Policy Decision Point (PDP),
+Policy Enforcement Point (PEP), Subject, Action, Resource, and Context from
+{{AUTHZEN}}.
+
+Issuance target:
+: The audience of the access being granted - the party the issued token
+  authorizes its bearer to act against. Usually the value the AS intends for
+  the token's `aud` claim.
+
+Gate tuple:
+: An evaluation request whose action expresses *issuance authority* - whether
+  the subject may obtain a token of a given type for the issuance target.
+  See {{gate-and-scope}}.
+
+Scope tuple:
+: An evaluation request whose action is a requested scope, expressing
+  *access authority*. See {{gate-and-scope}}.
+
+# Architecture {#architecture}
+
+~~~ ascii-art
++--------+           +----------------------+        +-------+
+| Client |           | Authorization Server |        |  PDP  |
++---+----+           |        (PEP)         |        +---+---+
+    |                +----------+-----------+            |
+    | 1. token req              |                        |
+    +-------------------------->|                        |
+    |                           | 2. authn client,       |
+    |                           |    validate grant      |
+    |                           |                        |
+    |                           | 3. evaluation request  |
+    |                           +----------------------->|
+    |                           |                        |
+    |                           | 4. decision + shaping  |
+    |                           |<-----------------------+
+    |                           |                        |
+    |                           | 5. mint per decision   |
+    |                           |    and shaping         |
+    | 6. token response         |                        |
+    |<--------------------------+                        |
+~~~
+
+Step 2 is unchanged from the underlying grant: the AS remains solely
+responsible for authenticating the client, validating the grant or subject
+token, and verifying any proof of possession. The PDP is consulted only
+after those checks succeed. A PDP permit does not substitute for any of
+them.
+
+# Deployment Considerations {#deployment}
+
+## Colocation and Latency {#colocation}
+
+A token endpoint can be a very high volume path. Multi-tenant authorization
+servers operate at request rates that leave a per-request budget in the low
+milliseconds, and an issuance decision that added a round trip to a remote
+service would not be deployable at that scale.
+
+This profile does not add one. {{AUTHZEN}} specifies a request and response
+contract between a Policy Enforcement Point and a Policy Decision Point; it
+does not specify where the Policy Decision Point runs. The PDP of
+{{architecture}} may be embedded in the authorization server's own process,
+loaded as a module or as a WebAssembly component, resident on the same host,
+or reached over a network. Conformance to this profile is a property of the
+messages exchanged and not of the topology that carries them, and
+deployments with the strictest budgets are expected to evaluate in process
+or on the same host. Step 3 of {{architecture}} is drawn as an arrow because
+it is a request, not because it is a hop.
+
+Two properties of the issuance moment make the budget more forgiving than
+the volume alone suggests.
+
+The decision is made once per token rather than once per request. An access
+token is presented many times, over a lifetime usually measured in minutes
+or hours, so the cost of deciding at issuance is amortized across every
+later presentation. This is the reverse of the resource server deployments
+{{AUTHZEN}} was first written for, where the decision recurs on every call
+and the budget is correspondingly tighter.
+
+The inputs are already in hand. By the time an AS reaches this decision it
+has authenticated the client, validated the grant, and resolved the subject.
+The evaluation request of {{request}} is assembled from values the AS
+already holds, and this profile implies no additional lookup to construct
+it.
+
+## Decisions That Cannot Be Made Synchronously {#deferred}
+
+Some issuance decisions cannot complete within the time a token request will
+wait, at any topology. A policy may call for human review, for an
+out-of-band approval, or for a check against a system whose own latency is
+unbounded.
+
+This document defines no mechanism for those, and does not need to.
+{{I-D.gerber-oauth-deferred-token-response}} defines a deferred token
+response, in which an authorization server that cannot answer immediately
+returns a deferral code and the client retrieves the outcome later. An AS
+implementing both may treat a decision it cannot obtain synchronously as a
+deferral rather than as a denial, evaluate it out of band, and apply the
+response of {{shaping}} to the token it eventually issues. Delay does not
+relax {{no-broadening}}: a decision that arrives late constrains the issued
+token exactly as one that arrives promptly would.
+
+## The Seam Inside the Authorization Server {#as-seam}
+
+{{architecture}} separates validating a grant from deciding whether to honor
+it, and asks a PDP only the second question. In a deployed authorization
+server that separation is often less clean than the figure. Credential
+handling, grant validation, session and consent state, and token minting are
+commonly one subsystem, with the inputs this profile needs distributed across
+it rather than exposed at any single point.
+
+The consequence is practical rather than normative. An authorization server
+that cannot assemble the fields of {{request}} at one point in its issuance
+path will have to introduce such a point, and for many implementations that
+will be the substantive work rather than the mapping or the response
+handling. This profile is defined in terms of the values an AS holds when it
+makes the decision, not in terms of where an implementation keeps them, so it
+constrains neither the internal structure nor the refactoring.
+
+# Forming the Evaluation Request {#request}
+
+## Subject {#subject}
+
+`subject` identifies the party the issued token will represent.
+
+`subject.type` MUST be one of the registered values in {{iana-types}}:
+
+* `user` - a natural person.
+* `client` - an OAuth client acting on its own behalf.
+* `workload` - a non-human software identity, such as a workload with a
+  cryptographic identity document.
+
+`subject.id` MUST be the identifier the AS intends to place in the issued
+token's subject claim. Where the AS applies a transformation to subject
+identifiers - pairwise or pseudonymous identifiers, or a mapping from an
+external identity to a local account - that transformation MUST be applied
+*before* the evaluation request is constructed, so that the identifier the
+PDP authorizes is the identifier the token carries.
+
+## Resource {#resource}
+
+For the gate and scope tuples of {{gate-and-scope}}, `resource.type` MUST be
+`audience` and each `resource.id` MUST be an issuance target. Authorization
+detail tuples name their resource differently, as {{rar-tuple}} sets out.
+
+A single registered type is used rather than a type per kind of target
+(service, trust domain, peer authorization server) because the type names
+the *protocol role* the target plays, not a guess at its nature. Policies
+written against `audience` port across deployments; policies written against
+locally invented type names do not.
+
+The **requested targets** of a request are the values it carries in a
+`resource` parameter in the sense of {{RFC8707}}, in an `audience` parameter
+where the binding defines one, or in both. Where the request carries neither,
+the AS's default audience for the grant is the sole requested target.
+
+### One Target Is the Preferred Shape {#one-target}
+
+A request SHOULD name a single target.
+
+This profile does not introduce that preference; it inherits it.
+{{RFC8707}} Section 5 encourages using only a single `resource` parameter,
+observing that a token valid at several protected resources "can be used by
+any one of those resources to access any of the others", so that multiple
+audiences presuppose a high degree of trust among the recipients.
+{{RFC9700}} Section 4.10.2 describes the same practice from the other
+direction: an access token is bound to a specific resource server, so a
+client reaching several obtains a token for each.
+
+An AS MAY reject a request naming more than one target. {{RFC8707}} Section 5
+anticipates this, noting that an authorization server may be unwilling or
+unable to fulfill such a request. Where the AS does reject one, the
+requirements of {{composition}} do not arise.
+
+### Several Targets {#several-targets}
+
+A request may nonetheless name more than one: {{RFC8707}} Section 2 permits
+the `resource` parameter to appear multiple times, and {{RFC8693}} Section 2.1
+permits the same of `audience` and `resource` in a token exchange request. An
+AS that accepts such a request has more than one issuance target, and whether
+the subject may reach each of them is a separate question.
+
+Because the information model of {{AUTHZEN}} carries exactly one resource per
+evaluation, a request naming several targets MUST be expressed as several
+evaluations rather than as one evaluation naming a compound target. The
+tuples of {{gate-and-scope}} are formed once for each requested target, and
+`resource` is carried on the individual evaluation object, overriding the
+top-level default as {{AUTHZEN}} Section 7.1.1 provides.
+
+This is also what makes the `audience` constraining key of {{shaping}}
+reachable. That key narrows a *set* of targets, and a set can only be
+narrowed if the request was able to put more than one member in it.
+
+{{ex-rar-two}} shows a two-target request on the wire.
+
+## Actions: Gate, Scope, and Authorization Detail Tuples {#gate-and-scope}
+
+Token issuance asks two questions that are frequently conflated:
+
+1. May this subject obtain *a token of this kind* for this target? This is
+   **issuance authority**, and in delegation scenarios, delegation
+   authority.
+2. May this subject exercise *this scope* at this target? This is **access
+   authority**.
+
+These are distinct privileges. {{RFC8693}} defines a `may_act` claim
+precisely because the authority to act on another party's behalf is not the
+same as the authority to access a resource. A subject may legitimately be
+permitted to hold an access token for an API while being forbidden from
+minting a delegated grant aimed at that same API.
+
+Because AuthZEN's information model provides exactly one action per
+evaluation, these two questions MUST be expressed as separate evaluations
+rather than as two interpretations of one `action.name`.
+
+A request carrying `authorization_details` ({{RFC9396}}) asks the second
+question in a richer vocabulary than a scope string, and gets a third tuple
+shape ({{rar-tuple}}) rather than a reinterpretation of the second.
+
+### Gate Tuple {#gate-tuple}
+
+A gate tuple is an evaluation whose `action.name` has three colon-separated
+segments:
+
+~~~
+issue:<token-type>:<grant-type>
+~~~
+
+where `<token-type>` and `<grant-type>` are short names registered in
+{{iana-actions}} - for example `issue:access_token:authorization_code`,
+`issue:id_token:authorization_code`, `issue:refresh_token:token_exchange`.
+
+The `issue:` prefix is reserved. A deployment MUST NOT use a scope value
+beginning with `issue:` as a scope tuple action. {{ex-cc}} shows a gate tuple
+in a request.
+
+The grant is part of the action because it is not recoverable from the rest
+of the tuple and it is not implied by the token type. The same subject,
+audience, and token type arise from an authorization code request and from
+its later refresh, and from a client requesting a token for itself and that
+same client exchanging for one. A policy that distinguishes those cases -
+requiring fresh authorization at a high-value audience, or permitting a
+client to hold a token but not to exchange for one - has nothing to attach
+to unless the grant is in the five-tuple.
+
+Neither segment subsumes the other. A single authorization code request may
+mint an access token, a refresh token, and an ID token, which are separately
+gateable; and a token exchange selects its output through
+`requested_token_type`, so its token type is a variable of the request.
+Together the two segments name one privilege: what may be minted, and by
+what means.
+
+### Action Name Portability {#action-portability}
+
+Short names registered under {{iana-actions}} MUST match
+`[a-z][a-z0-9_]{0,30}`, and a composed gate action name MUST NOT exceed 50
+characters.
+
+The bounds exist for portability. Relationship-based engines commonly
+validate relation identifiers against a restricted grammar, admitting a small
+character set within a modest length limit. A PDP built on such an engine can
+canonicalize an action name defined by this document by replacing each `:`
+with a character the grammar admits, conventionally `_`. The bounds above are
+what make that transformation total: any registered name survives it, so a
+policy written against these names ports without being rewritten.
+
+Carrying a grant type URI verbatim would not survive it. The composed action
+name would exceed the length limits such grammars impose before any question
+of characters arose.
+
+The guarantee covers only the vocabulary this document defines. Scope values
+are carried verbatim ({{scope-tuple}}) and routinely contain characters no
+such grammar admits; mapping them remains internal to the PDP.
+
+### Scope Tuple {#scope-tuple}
+
+A scope tuple is an evaluation whose `action.name` is a single requested
+scope value, carried verbatim.
+
+Scope values are not transformed into policy-engine relation names by the
+AS. Any such mapping is internal to the PDP. This keeps `action.name` a
+stable interface: the AS reports what the client asked for, and the PDP
+decides what that means in its own policy vocabulary.
+
+{{ex-downscope}} shows three scope tuples behind a gate, one of them denied.
+
+### Authorization Detail Tuple {#rar-tuple}
+
+Where the request carries `authorization_details` ({{RFC9396}}), each entry
+in the array yields one or more evaluations.
+
+An entry is a product, not a single permission. {{RFC9396}} Section 2.2:
+"When different common data fields are used in combination, the permissions
+the client requests are the product of all the values. The object represents
+a request for all `actions` values listed within the object to be used at all
+`locations` values listed within the object for all `datatypes` values listed
+within the object." Figure 6 of that document is the client's escape hatch: a
+client that does not want the whole product sends several entries instead.
+Asking the PDP one question per cell therefore asks exactly the questions the
+entry poses, and asking fewer answers a coarser question than the client
+asked.
+
+The AS forms one evaluation per cell:
+
+| RAR member | AuthZEN |
+|---|---|
+| `type` | `resource.type` |
+| each `locations` value | `resource.id` |
+| each `actions` value | `action.name`, leading segments |
+| each `datatypes` value | `action.name`, final segment |
+
+`action.name` is the `actions` value alone where the entry has no
+`datatypes`, and the `actions` value and the `datatypes` value joined by a
+colon otherwise, the datatype last:
+
+~~~
+<action>
+<action>:<datatype>
+~~~
+
+The datatype is recovered as the segment following the final colon. An AS
+MUST NOT form a compound name where the `datatypes` value itself contains a
+colon; such an entry is decomposed on `locations` and `actions` only, and its
+datatype axis is narrowed on the response side alone ({{rar-response}}).
+
+These names cannot be confused with the gate names of {{gate-tuple}}. A gate
+tuple always names a resource whose type is `audience`; an authorization
+detail tuple never does, because `resource.type` is the entry's own `type`.
+The two may name the same `resource.id` and remain distinct questions, which
+{{ex-rar-one}} shows.
+
+{{ex-rar-two}} shows an entry decomposing into the four cells of a two by two
+product, and one of them denied.
+
+Only `type` is REQUIRED of an entry ({{RFC9396}} Section 2), so an axis may
+be absent:
+
+| Absent member | Substituted |
+|---|---|
+| `locations` | Each requested target of {{resource}} |
+| `actions` | The reserved name `authorization_detail` |
+| `datatypes` | No compounding; `action.name` is the action alone |
+
+Substituting the requested targets for an absent `locations` continues the
+audience restriction the member itself performs. {{RFC9396}} Section 12
+describes `locations` as preventing unintended client authorizations "through
+audience restriction", and Section 9.1 recommends that an AS minting a JWT
+access token filter the authorization details to the specific audience. Where
+an entry names no location, the request's own targets are the audience it is
+restricted to.
+
+`privileges` and `identifier` are not decomposed. Section 2.2's product
+sentence names actions, locations, and datatypes, so whether `privileges`
+multiplies is unstated, and `identifier` is a scalar with no multiplicity.
+
+Nor does the decomposition reach a type that carries its multiplicity in
+type-specific members rather than in the common data fields - a consent
+object enumerating individual permissions, for instance. Such an entry
+yields one evaluation per location. This is the prevailing shape in deployed
+open banking profiles, so it is not a corner case.
+
+An undecomposed member is not shown to the PDP, and a PDP cannot narrow
+against a value it was not sent. What it can still do is narrow by policy:
+knowing the subject, the type, and the location, it may return an entry
+whose `datatypes` or type-specific members are the most this subject may
+ever reach there. Such an entry is still subject to the structural check of
+{{rar-response}}, so a PDP that returns more than was requested has its
+decision rejected rather than trimmed. Narrowing against the request itself
+remains the AS's own obligation under {{RFC9396}} Section 6.
+
+Decomposing the entry is also what makes the structural check of
+{{rar-response}} derivable rather than asserted. An entry whose `locations`,
+`actions`, and `datatypes` are subsets of the request's is exactly an entry
+reassembled from cells the PDP permitted.
+
+### Gate Tuples Are Always Present {#gate-required}
+
+An AS MUST include a gate tuple in every evaluation request it forms under
+this profile. A binding MAY require more than one ({{composition}}).
+
+The floor is therefore two evaluations for a single-target request naming
+scopes, and one for a single-target request naming none. Deployments are
+expected to write issuance policy
+for every token type and grant combination their AS can produce; a PDP that
+advertises support for this profile renders a decision on any registered gate
+action it is sent ({{discovery}}), so an AS never has to predict which
+combinations a given PDP has policy for.
+
+## Context
+
+The `context` object carries advisory input. A conforming PDP MUST be able
+to render a decision without it.
+
+The following keys are defined by this document; bindings may define more:
+
+| Key | Type | Value |
+|---|---|---|
+| `client_id` | string | The authenticated client identifier |
+| `acr` | string | Authentication context class of the subject |
+| `amr` | array of strings | Authentication methods, per {{RFC8176}} |
+| `auth_time` | integer | Time of authentication, as in {{RFC7519}} |
+| `cnf` | object | Confirmation method of the presented credential |
+| `jti` | string | Identifier of the token the AS intends to mint ({{correlation}}) |
+
+The single-type rule of {{envelope}} applies here as well: each key above has
+one JSON type, and bindings defining further context keys MUST state a type
+for each.
+
+Per {{design-goals}}, any input on which the decision genuinely depends
+belongs in the five-tuple, not here. The grant type is the worked example:
+it is decision-critical, so it is a segment of the gate action name
+({{gate-tuple}}) and does not appear in `context` at all.
+
+### Correlation {#correlation}
+
+An operator running an authorization server against a separately operated
+policy decision point has two decision logs and no defined way to join them.
+An AS MAY include in `context` the `jti` of the token it intends to mint, so
+that the record the PDP writes and the token the AS issues carry the same
+identifier.
+
+It is a MAY because of an ordering problem: at evaluation time the token does
+not exist, so an AS that sends a `jti` has allocated it in advance, and on a
+denial that identifier is spent on a token that is never issued. Whether to
+pre-allocate, and what to do with identifiers spent on denied requests, is an
+implementation matter for the AS and is outside the scope of this document.
+An AS that does not pre-allocate omits the key.
+
+Supplying `jti` as an input does not disturb the reservation in {{claims}}.
+The AS remains authoritative for the claim, and a PDP MUST NOT set it in the
+response.
+
+## Batching and Result Composition {#composition}
+
+### Forming the Batch {#batch}
+
+For each requested target ({{resource}}), the AS forms:
+
+- a gate tuple ({{gate-tuple}}), and
+- one scope tuple ({{scope-tuple}}) for each requested scope,
+
+each carrying that target as its `resource`. Where the request carries
+`authorization_details`, the AS also forms the authorization detail tuples of
+{{rar-tuple}}, which carry a resource of their own.
+
+This document produces one gate tuple per target. Bindings may produce more:
+the token exchange family evaluates the authority of the requesting party
+separately from that of the subject, and so produces two per target.
+
+Where a request yields more than one tuple, the AS MUST use the Access
+Evaluations API of {{AUTHZEN}} with `options.evaluations_semantic` set to
+`execute_all`, and MUST place gate tuples at the leading indices of the
+`evaluations` array, beginning at index 0. The response lists decisions in
+request order ({{AUTHZEN}} Section 7.2), so the AS recovers which target,
+scope, or authorization detail cell each decision belongs to by position.
+
+A request reduces to a single evaluation only when it names one target, no
+scopes, and no authorization details, in which case the gate tuple stands
+alone. {{ex-no-scopes}} is that case, and {{ex-cc}} the smallest batch.
+
+`execute_all` is required because a denial must be able to narrow the grant
+rather than fail it. {{AUTHZEN}} evaluation semantics are selected per request
+and cannot mark an individual batch item as a precondition, so the composition
+rules below are enforced by the AS. This is well within the PEP's role - the
+AS is already interpreting per-item results in order to downscope.
+
+### The Batch Carries Only the Residue {#residue}
+
+Before forming the batch, an AS MUST apply the reductions it is itself
+authoritative for, and MUST form tuples only for what survives them.
+
+Those reductions already exist. {{RFC6749}} Section 3.3 permits an AS to
+issue a token whose scope is narrower than the one requested. {{RFC9396}}
+Section 6 is stronger still: the AS "checks whether the underlying grant ...
+or the client's policy ... allows the issuance of an access token with the
+requested authorization details", and refuses with
+`invalid_authorization_details` where it does not. Neither is introduced
+here; this profile only fixes their order relative to the PDP call.
+
+The reason to fix that order is {{no-broadening}}. A PDP may narrow what is
+issued and may not broaden it, so a permit on something the AS had already
+decided to refuse cannot change the outcome. Asking anyway writes a decision
+into the PDP's record that corresponds to no issued authority, which is
+worse than not asking: the two logs the profile is otherwise careful to let
+an operator join ({{correlation}}) stop agreeing.
+
+The batch therefore expresses the request as the AS is prepared to grant it,
+and the PDP narrows from there.
+
+### The Batch Is Bounded {#bounded}
+
+What remains after that reduction is still sized by the client. An AS MUST
+bound the number of evaluations it will form for a single token request, and
+MUST reject a request that would exceed the bound.
+
+This document does not specify the value. {{RFC9126}} Section 2.3 is the
+precedent: it directs an AS to answer an oversized pushed request with 413
+and an over-frequent client with 429, and names no number for either. The
+bound that is right for a deployment depends on its PDP, and a number written
+here would be wrong somewhere.
+
+The error is the one belonging to the parameter that overran the bound:
+`invalid_authorization_details` ({{RFC9396}} Section 6), `invalid_scope`
+({{RFC6749}}), or, for token exchange requests, `invalid_target`
+({{RFC8693}}). Where more than one contributed, any of them is correct.
+`invalid_request` is not, because it does not tell the client what to
+shorten.
+
+### A Denied Gate Removes a Target {#gate-denial}
+
+A gate tuple governs one target. Where its decision is `false`, that target
+is removed from the request: the AS MUST NOT name it in the audience of any
+token it issues, and MUST disregard the scope tuples formed for it and any
+authorization detail tuple naming it as `resource.id`.
+
+Where every target is removed, the AS MUST fail the request and MUST NOT
+issue a token. For token exchange requests the appropriate error is
+`invalid_target` ({{RFC8693}}).
+
+An AS MAY instead fail the whole request when any gate is denied.
+{{one-target}} already permits it to refuse a multi-target request outright,
+and an AS unwilling to issue a token for a subset of what was asked for is
+exercising the same discretion later. {{ex-rar-two}} closes on what a denied
+gate would have removed from the batch shown there.
+
+Where one target was requested, both rules coincide: a denied gate fails the
+request.
+
+### A Denied Scope Must Narrow Every Target {#scope-denial}
+
+A scope tuple governs one scope at one target. A scope is carried in the
+issued token only where it was permitted at *every* surviving target. The AS
+reports the reduced set in the `scope` response parameter, as {{RFC6749}}
+already requires.
+
+This intersection is not introduced here. {{RFC9068}} Section 2.2.3 requires
+that "all the individual scope strings in the `scope` claim MUST have meaning
+for the resources indicated in the `aud` claim"; the plural is the operative
+part. Section 3 of the same document requires that an AS "MUST NOT issue a
+JWT access token if the authorization granted by the token would be
+ambiguous". A scope permitted at one audience and denied at another, carried
+in a token naming both, is that ambiguity exactly: no recipient can determine
+whether the scope was granted for itself or for the other.
+
+An AS that wants a scope to survive at one target and not another issues a
+token per target, which is the shape {{one-target}} prefers in the first
+place.
+
+Where the request named scopes and none survive, and no authorization detail
+entry survives either, the AS MUST fail the request rather than issue an
+empty token, even though the gate permitted it. A permitted gate authorizes a
+token of that kind to exist; it does not authorize an empty one.
+
+{{ex-downscope}} shows a partial denial narrowing a single-target request.
+
+### A Denied Cell Narrows an Entry {#rar-denial}
+
+An authorization detail tuple governs one cell of one entry. The AS
+reassembles each entry from the cells that were permitted, so that a denied
+cell narrows the entry rather than failing it.
+
+The surviving cells of an entry need not be expressible as one entry, since
+an entry is a product and the survivors need not be a rectangle. Where they
+are not, the AS reassembles them as several entries of the same `type`, which
+is the shape Figure 6 of {{RFC9396}} defines for a client wanting exactly
+this. An AS MUST NOT instead widen the result to the smallest single entry
+containing the survivors, which would return a cell the PDP denied.
+{{ex-rar-two}} works through such a split.
+
+Where an entry's `locations` was absent and its tuples were therefore fanned
+across several targets, a cell survives only where it was permitted at every
+surviving target, for the reason given in {{scope-denial}}.
+
+An entry with no surviving cells is dropped. Where the request carried
+`authorization_details` and no entry survives, the AS MUST fail the request
+with `invalid_authorization_details`, which {{RFC9396}} Section 6 already
+defines for a token request whose authorization details the AS will not
+grant.
+
+Reassembly is what the AS does absent a `authorization_details` key in the
+response. Where the PDP returns one, it replaces the reassembled array and is
+checked against the request as {{rar-response}} requires.
+
+# Processing the Evaluation Response {#shaping}
+
+A PDP MAY return, in the response `context`, information that shapes the
+token the AS issues.
+
+## The `issuance` Envelope {#envelope}
+
+All keys defined by this profile appear within a single `issuance` member of
+the response `context`:
+
+~~~ json
+{
+  "decision": true,
+  "context": {
+    "reason_admin": { "200": "matched policy P-4471" },
+    "issuance": {
+      "token_lifetime": 300,
+      "claims": { "groups": ["engineering"] }
+    }
+  }
+}
+~~~
+
+An AS implementing this profile MUST process `context.issuance` and MUST
+ignore unrecognized members outside it, preserving the advisory character
+that {{AUTHZEN}} gives response context generally.
+
+The examples of {{examples}} carry the envelope on live responses:
+`token_lifetime` in {{ex-cc}}, `claims` in {{ex-downscope}}, and
+`granted_scope` in {{ex-no-scopes}}.
+
+Every key defined below has exactly one JSON type, and bindings that define
+further keys MUST do the same. Where the corresponding OAuth or JWT
+construct admits more than one - `aud` is the notable case, per Section
+4.1.3 of {{RFC7519}} - this profile picks one rather than carrying the
+polymorphism forward. An AS validates the response context before acting on
+it, and a union type costs more to validate, to schematize, and to project
+into a typed representation than the shorthand saves.
+
+## Mandatory-to-Understand {#mtu}
+
+{{AUTHZEN}}, in the definitions of the `decision` values in its Decision
+section, states that where a PEP does not understand information in the
+response context, the PEP MAY reject the decision. That permission is
+appropriate for a general-purpose API in which response context is advisory.
+It is not sufficient here, because the consequences are asymmetric:
+
+* Ignoring a key that **narrows** the grant yields a token **broader than
+  the PDP authorized** - a silent privilege escalation.
+* Ignoring a key that **adds** information yields a token narrower than
+  intended - a functional shortfall, not a security failure.
+
+This profile therefore adopts the following rule, from which the treatment
+of every key below is derived:
+
+> A response-context key is mandatory-to-understand if and only if ignoring
+> it would produce a token broader than the PDP authorized. For such keys,
+> an AS that does not understand and apply the key MUST treat the permit as
+> a denial.
+
+## No Broadening {#no-broadening}
+
+A PDP MUST NOT return a shaping value that grants access the AS would not
+otherwise have granted, and an AS MUST reject a decision that attempts it.
+
+The PDP decides whether and how much; it does not decide what else. Without
+this rule, an evaluation of `files.read` could return a token bearing
+`admin`, and the token would assert a privilege no evaluation ever
+considered.
+
+## Constraining Keys
+
+The keys in this section are mandatory-to-understand under {{mtu}}.
+
+### `granted_scope`
+
+A space-delimited string in the syntax of the `scope` parameter of
+{{RFC6749}}, giving the scope set the AS is authorized to grant.
+
+`granted_scope` MUST be a subset of the scopes the AS would otherwise have
+granted - the requested scopes, or for a request naming none, the AS's
+default set for that client and target. The AS MUST reject the decision
+otherwise.
+
+Its principal use is the gate-only evaluation, where there are no scope
+tuples and this key is how a PDP answers "permit, and grant this set."
+Enumerating a grantable set is a search operation rather than a check; a PDP
+unable to perform it returns a bare permit and the AS falls back to its own
+defaults, which is a safe degradation.
+
+Where scope tuples are present, the per-item decisions already express
+downscoping, and a PDP SHOULD NOT also return `granted_scope`.
+
+### `token_lifetime`
+
+A non-negative integer number of seconds, interpreted as a **ceiling**. The
+AS MUST issue a token whose lifetime is the lesser of this value and the
+lifetime it would otherwise have used. It is never a floor: a PDP cannot
+extend a token's life beyond the AS's own policy.
+
+A value of `0` MUST be treated as a denial rather than as an instruction to
+mint an already-expired token.
+
+### `audience`
+
+An array of strings, narrowing the set of targets for which the token may be
+issued. Every value MUST be the `resource.id` of the evaluation on which it
+was returned, so the array is either that single target or empty. An
+evaluation is a decision about one target, and this key lets a PDP withhold
+that target while still permitting the request; it does not let one
+evaluation speak for another.
+
+An empty array therefore withdraws the target that evaluation was about,
+with the same effect as the denied gate of {{gate-denial}}. Where no target
+survives, the AS MUST fail the request; for token exchange requests the
+appropriate error is `invalid_target` ({{RFC8693}}).
+
+The value is an array even when it names a single target, per the
+single-type rule above. An AS remains free to render a single-element set as
+a bare string in the token's own `aud` claim, where {{RFC7519}} permits it.
+
+### `authorization_details` {#rar-response}
+
+An array in the syntax of {{RFC9396}}, replacing - not merged with - the
+authorization details of the request.
+
+Where the PDP returns nothing, the AS reassembles the entries itself from the
+cells its authorization detail tuples ({{rar-tuple}}) permitted. The key
+exists for the narrowing the cells cannot express: within a type-specific
+member, or along an axis {{rar-tuple}} does not decompose.
+
+Replacement admits arbitrary structured narrowing, which is what a PDP
+filtering rich authorization requests needs, but "narrower" is not decidable
+for arbitrary authorization detail types. This profile therefore requires:
+
+* **Structural check, always.** Every returned entry MUST be covered by a
+  single entry of the request: there MUST exist a request entry with the same
+  `type` whose `locations`, `actions`, and `datatypes` members are supersets
+  of the returned entry's. Several returned entries MAY be covered by the same
+  request entry, which is the shape {{rar-denial}} produces. The AS MUST
+  reject the decision if any returned entry is covered by no request entry, or
+  is covered only by several of them taken together. Where a request carries
+  `read` on `contacts` in one entry and `write` on `photos` in another, as
+  Figure 6 of {{RFC9396}} does, an entry returning `read` on `photos` is
+  within the union of the two and within neither, and names a permission the
+  client did not request.
+* **Absent members.** A member absent from the covering request entry
+  constrains nothing, and a returned entry MAY carry a member the request
+  omitted: the client asked for the entry unrestricted along that axis, so
+  any value the PDP supplies narrows it, which is the policy narrowing
+  {{rar-tuple}} describes. `locations` is the exception, since
+  {{rar-tuple}} substitutes the requested targets where it is absent. A
+  returned entry MUST NOT name a location that is neither in the covering
+  request entry nor a requested target of {{resource}}.
+* **Type-specific members.** For members beyond those defined in
+  {{RFC9396}}, the AS MUST either apply a validator specific to that
+  authorization details type or reject the decision. An AS MUST NOT pass
+  unvalidated structure into an issued token.
+
+### `crit`
+
+An array of strings naming members of `claims` ({{claims}}) that are
+themselves mandatory-to-understand. The name and semantics are taken from
+the `crit` header parameter of {{RFC7515}}: an AS that does not understand
+and apply a named member MUST treat the permit as a denial.
+
+`crit` exists because the static classification in this section is
+incomplete. A member of `claims` is normally safe to drop, and is
+occasionally the constraint that made the permit safe.
+
+Consider a PDP that permits a payment and returns:
+
+~~~ json
+{
+  "decision": true,
+  "context": {
+    "issuance": {
+      "claims": { "max_transfer_eur": 500 },
+      "crit": [ "max_transfer_eur" ]
+    }
+  }
+}
+~~~
+
+The ceiling is enforced by the resource server, which reads it from the
+token. An AS that drops the claim issues a token that says nothing about a
+limit: the resource server has nothing to enforce, and a decision that
+authorized 500 euros has become an authorization for any amount. No
+statically classified key catches this, because the scope, lifetime,
+audience, and authorization details are all exactly what the PDP allowed and
+the claim is the only thing that made them safe.
+
+An AS may drop a claim for ordinary reasons, most often because it emits only
+claim names on an allowlist. The vocabulary is domain-specific, so neither
+party can settle the question in advance, and the AS learns at response time
+that it cannot carry the claim. `crit` is what makes that a denial rather
+than a silent broadening.
+
+## Decorating Keys
+
+### `claims` {#claims}
+
+An object whose members are claim names, in the sense of {{RFC7519}}, and
+the values to be included in the issued token. This is the mechanism by
+which attributes computed during the decision itself reach the token: a
+ceiling the policy derived while evaluating a limit, a risk tier that
+determined the outcome, a structured result a binding defines.
+
+It is not the mechanism for enumerating what a subject holds. For the group
+memberships, roles, and entitlements that {{RFC9068}} describes for JWT
+access tokens, drawn from the schema of {{RFC7643}}, the search operations of
+{{AUTHZEN}} answer the question directly, and the companion profile in
+{{companions}} specifies how an AS calls them and composes the results. A PDP
+MAY return such a claim in `claims` where its policy computes one.
+
+Members of `claims` are advisory under {{mtu}}: an AS that drops them issues
+a less capable token. A PDP that requires a member to be honored MUST name
+it in `crit`.
+
+A PDP MUST NOT set, and an AS MUST reject a response that sets, any of the
+following claims:
+
+| Reserved | Rationale |
+|---|---|
+| `iss`, `iat`, `jti` | Provenance, for which the AS is authoritative |
+| `sub` | It is `subject.id`, an input to the decision |
+| `aud` | It is `resource.id`, an input to the decision |
+| `exp`, `nbf` | Expressed by `token_lifetime` |
+| `scope` | Expressed by `granted_scope` |
+| `client_id` | Established by client authentication |
+| `cnf` | Derived from a proof of possession the AS verified |
+| `act` | Delegation chain, constructed by the AS |
+| `authorization_details` | Has its own key and narrowing rules |
+| `may_act` | Confers future delegation authority; broadening by construction |
+
+The entries for `sub` and `aud` rest on stronger ground than the rest. Both
+are inputs to the five-tuple; a PDP that could rewrite either would cause the
+AS to issue a token corresponding to a decision that was never evaluated.
+Re-subjecting a token is a fresh issuance, not an attenuation of an existing
+one, and MUST be evaluated as such.
+
+## Aggregation Across a Batch {#aggregation}
+
+An Access Evaluations response in {{AUTHZEN}} carries no top-level context;
+each element of the `evaluations` array is a decision with its own optional
+context. Token shaping, however, is a property of the token: there is one
+lifetime, one claim set, one authorization details array for the token being
+minted, while this profile fans scopes, targets, and authorization detail
+cells out across many evaluations.
+
+An AS MUST therefore compose per-item shaping as follows:
+
+| Key | Aggregation |
+|---|---|
+| `token_lifetime` | Minimum over permitted items |
+| `granted_scope` | Union over permitted items, intersected with what the AS would otherwise grant and with the surviving scopes of {{scope-denial}} |
+| `audience` | The surviving targets of {{gate-denial}}, less any target whose item returned an empty array |
+| `authorization_details` | Union of entries, then the per-entry structural check, intersected with the entries reassembled under {{rar-denial}} |
+| `claims` | Merge; see below |
+| `crit` | Union |
+
+Shaping keys appearing in the context of a **denied** item MUST be ignored.
+
+Where two permitted items return different values for the same member of
+`claims`, the AS MUST reject the decision. There is no general narrowing
+merge for arbitrary JSON values, and choosing one arbitrarily could
+broaden the result. Identical values are not a conflict. A PDP SHOULD return
+token-level shaping on a single item to avoid the situation.
+
+# Discovery {#discovery}
+
+A PDP supporting this profile MUST advertise the capability URN registered
+in {{iana-capability}} in the `capabilities` member of its metadata document,
+retrievable at `/.well-known/authzen-configuration`:
+
+~~~ json
+{
+  "policy_decision_point": "https://pdp.example.com",
+  "access_evaluation_endpoint":
+      "https://pdp.example.com/access/v1/evaluation",
+  "access_evaluations_endpoint":
+      "https://pdp.example.com/access/v1/evaluations",
+  "capabilities": [
+    "urn:openid:authzen:capability:token-issuance"
+  ]
+}
+~~~
+
+The URN asserts support for the request mapping and response vocabulary of
+this document. It is not a statement about the content of the PDP's policy,
+and a PDP MUST NOT be read as claiming to hold rules for any particular
+issuance. What a deployment's policy permits is disclosed only through
+decisions. This is the same line
+{{I-D.ietf-oauth-identity-assertion-authz-grant}} draws for
+`authorization_grant_profiles_supported`, which indicates that a server
+implements a profile's processing rules and not that any particular issuer,
+client, subject, or audience will be accepted.
+
+Advertising the capability is accordingly a commitment to the request shapes
+this profile can produce. A PDP that advertises it MUST render a decision for
+a gate tuple naming any action name composable from the short names
+registered in {{iana-actions}}, and MUST NOT reject the evaluation on the
+grounds that it holds no policy for that action. Denying is a decision; a
+protocol error is not. The same applies to a batch that mixes a gate tuple
+with scope tuples, which is the ordinary shape of a request naming scopes
+({{composition}}).
+
+The obligation matters because the gate vocabulary is a product of two
+registries and grows as bindings register short names. An AS pairs the token
+type it is about to mint with the grant it received; it cannot know which
+pairings a given deployment's policy anticipated, and must not have to.
+
+For the same reason, this profile defines one capability URN rather than one
+per token type and grant combination. Finer granularity would oblige the AS
+to predict what the PDP has policy for, which the rule above exists to avoid,
+and would publish the shape of a deployment's issuance policy in an
+unauthenticated metadata document. Capability granularity in this profile
+tracks vocabulary, not policy. An extension that adds response vocabulary
+registers its own URN, since an AS must understand what it is asked to
+enforce; one that adds only advisory context keys or new registered action
+names does not, since a PDP ignores a context key it does not recognize and
+the rule above already obliges it to decide any registered gate action.
+
+An operator enabling a new grant or token type nonetheless has a real
+question to answer: whether the deployment's policy anticipates the gate
+actions the AS is about to start sending, or whether every such request will
+be denied. That question is about policy content, so its answer belongs on
+the authenticated evaluation surface rather than in metadata; {{AUTHZEN}}
+notes that an unauthenticated PDP can be probed for the shape of its policy.
+The Action Search API of {{AUTHZEN}} answers it directly: a search for a
+representative subject and an `audience` resource returns the action names
+policy would permit, and gate actions among them indicate the issuances the
+deployment is prepared for. This is a deployment-time check, not a
+per-request one, and nothing in this profile requires it.
+
+# Error Mapping
+
+| Condition | Authorization server behavior |
+|---|---|
+| Gate tuple denied | Fail the request; do not issue |
+| All scope tuples denied | Fail the request; `invalid_scope` |
+| Some scope tuples denied | Issue with the permitted subset; report via `scope` |
+| Target denied or empty audience set | `invalid_target` ({{RFC8693}}) |
+| No authorization detail entry survives | `invalid_authorization_details` ({{RFC9396}}) |
+| Batch would exceed the bound of {{bounded}} | The error of the parameter that overran it |
+| Shaping key violates {{no-broadening}} | Treat as denial; fail the request |
+| Unknown `crit` member | Treat as denial; fail the request |
+| PDP unreachable or malformed response | Fail closed; do not issue |
+
+Reason information returned by a PDP is diagnostic and intended for the
+operator of the AS. An AS MUST NOT relay PDP reason strings to the client,
+as they may disclose policy structure to a party that is not authorized to
+learn it.
+
+Where a PDP returns a denial accompanied by authentication requirements -
+the step-up pattern of {{AUTHZEN}}, in which the required `acr` and `amr`
+values are named - an AS SHOULD surface the requirement to the client. This
+document does not define that mapping, and neither end of it is presently
+specified. {{AUTHZEN}} illustrates the pattern in a non-normative example
+rather than defining the response context keys that carry it, leaving a
+profile nothing normative to reference; and on the OAuth side,
+`insufficient_user_authentication` in {{RFC9470}} is defined for resource
+servers rather than for the token endpoint, where no equivalent signal
+exists. This is an open item, and closing it requires work in both
+specifications.
+
+# Examples {#examples}
+
+The first example below is shown in full, framed against the HTTPS JSON
+binding of {{AUTHZEN}}. The remaining examples show only the JSON payload.
+Each is referenced from the section that specifies the rule it exercises.
+
+The transport is a property of the deployment, not of this profile: an
+evaluation carrying the mapping defined here is the same evaluation whatever
+binding conveys it. Where the HTTPS JSON binding is in use, the request URL
+is the PDP's `access_evaluations_endpoint`, or `access_evaluation_endpoint`
+for a request that reduces to a single evaluation, as published in the PDP's
+metadata; the paths shown below are the defaults that apply when metadata
+provides no value.
+
+## Client Credentials, One Scope {#ex-cc}
+
+One scope is requested, so the request is one gate tuple ({{gate-tuple}}) and
+one scope tuple ({{scope-tuple}}). This is the floor: two evaluations, so the
+Access Evaluations API. One target is shared by both, so `resource` is carried
+once at the top level; the examples below that need a resource per evaluation
+carry it there instead, as {{several-targets}} provides.
+
+~~~ http-message
+POST /access/v1/evaluations HTTP/1.1
+Host: pdp.example.com
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "subject":  { "type": "client", "id": "svc-reporting" },
+  "resource": {
+    "type": "audience",
+    "id": "https://telemetry.example"
+  },
+  "context": { "client_id": "svc-reporting" },
+  "evaluations": [
+    {
+      "action": {
+        "name": "issue:access_token:client_credentials"
+      }
+    },
+    { "action": { "name": "telemetry.write" } }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+~~~ http-message
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "evaluations": [
+    {
+      "decision": true,
+      "context": { "issuance": { "token_lifetime": 900 } }
+    },
+    { "decision": true }
+  ]
+}
+~~~
+
+## Authorization Code, Downscoping {#ex-downscope}
+
+Three scopes are requested. The gate leads at index 0 and `execute_all`
+allows the AS to issue the permitted subset of the rest, per
+{{scope-denial}}.
+
+~~~ json
+{
+  "subject":  { "type": "user", "id": "U0405936" },
+  "resource": {
+    "type": "audience",
+    "id": "https://api.example/files"
+  },
+  "context": {
+    "client_id": "chatterbox",
+    "acr": "urn:example:loa:2"
+  },
+  "evaluations": [
+    {
+      "action": {
+        "name": "issue:access_token:authorization_code"
+      }
+    },
+    { "action": { "name": "files.read"   } },
+    { "action": { "name": "files.write"  } },
+    { "action": { "name": "files.delete" } }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+~~~ json
+{
+  "evaluations": [
+    { "decision": true },
+    {
+      "decision": true,
+      "context": {
+        "issuance": { "claims": { "groups": ["engineering"] } }
+      }
+    },
+    { "decision": true },
+    {
+      "decision": false,
+      "context": { "reason_admin": { "403": "policy P-118" } }
+    }
+  ]
+}
+~~~
+
+The AS issues a token bearing `files.read files.write`, a `groups` claim,
+and reports the reduced scope set in the token response.
+
+Had the same subject arrived at the same audience with the same scopes on a
+refresh, index 0 would have read
+`issue:access_token:refresh_token`, and a policy that requires fresh
+authorization here could deny it while leaving the scope tuples untouched.
+
+## No Scopes Requested {#ex-no-scopes}
+
+No scopes and no default set, so the gate tuple stands alone ({{batch}}). This
+is the only shape this document produces that is a single evaluation, and it is
+therefore the only one sent to the Access Evaluation API rather than the
+Access Evaluations API: the payload is a bare evaluation with no
+`evaluations` array, and under the HTTPS JSON binding it is a `POST` to
+`/access/v1/evaluation`.
+
+~~~ json
+{
+  "subject":  { "type": "client", "id": "svc-reporting" },
+  "action":   {
+    "name": "issue:access_token:client_credentials"
+  },
+  "resource": {
+    "type": "audience",
+    "id": "https://telemetry.example"
+  },
+  "context": { "client_id": "svc-reporting" }
+}
+~~~
+
+~~~ json
+{
+  "decision": true,
+  "context": {
+    "issuance": {
+      "granted_scope": "telemetry.write",
+      "token_lifetime": 900
+    }
+  }
+}
+~~~
+
+## Authorization Details, One Entry {#ex-rar-one}
+
+The token request below carries one authorization details entry naming one
+location, one action, and one datatype. Line breaks in the request body are
+for display only, and the value of `authorization_details` is form encoded on
+the wire ({{RFC9396}} Section 2.1); it is shown decoded in the block that
+follows.
+
+~~~ http-message
+POST /token HTTP/1.1
+Host: as.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code=SplxlOBeZQQYbYS6WxSbIA
+&resource=https%3A%2F%2Fexample.com%2Fcustomers
+&authorization_details=...
+~~~
+
+~~~ json
+[
+  {
+    "type": "customer_information",
+    "locations": [ "https://example.com/customers" ],
+    "actions": [ "read" ],
+    "datatypes": [ "contacts" ]
+  }
+]
+~~~
+
+The entry has one cell, so the batch is the gate tuple and one authorization
+detail tuple. The two name the same URI and are still distinct evaluations:
+the gate asks whether a token may be issued for that audience, and the
+authorization detail tuple asks whether this subject may read contacts at
+that API. `resource.type` is what separates them.
+
+~~~ json
+{
+  "subject": { "type": "user", "id": "U0405936" },
+  "context": {
+    "client_id": "chatterbox"
+  },
+  "evaluations": [
+    {
+      "action": {
+        "name": "issue:access_token:authorization_code"
+      },
+      "resource": {
+        "type": "audience",
+        "id": "https://example.com/customers"
+      }
+    },
+    {
+      "action": { "name": "read:contacts" },
+      "resource": {
+        "type": "customer_information",
+        "id": "https://example.com/customers"
+      }
+    }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+~~~ json
+{
+  "evaluations": [
+    { "decision": true },
+    { "decision": true }
+  ]
+}
+~~~
+
+Every cell was permitted, so the entry reassembles to itself and the AS
+issues a token carrying the requested `authorization_details` unchanged.
+
+## Authorization Details Across Two Targets {#ex-rar-two}
+
+Here the request names two issuance targets, and its single entry names two
+locations and two datatypes. One action across two locations and two
+datatypes is four cells, and two targets is two gate tuples, so the batch is
+six evaluations. Gate tuples lead, per {{batch}}.
+
+~~~ json
+[
+  {
+    "type": "customer_information",
+    "locations": [
+      "https://example.com/customers",
+      "https://eu.example.com/customers"
+    ],
+    "actions": [ "read" ],
+    "datatypes": [ "contacts", "photos" ]
+  }
+]
+~~~
+
+No top-level `resource` is shown, because no one resource is shared: each
+evaluation carries its own.
+
+~~~ json
+{
+  "subject": { "type": "user", "id": "U0405936" },
+  "context": {
+    "client_id": "chatterbox"
+  },
+  "evaluations": [
+    {
+      "action": {
+        "name": "issue:access_token:authorization_code"
+      },
+      "resource": {
+        "type": "audience",
+        "id": "https://example.com/customers"
+      }
+    },
+    {
+      "action": {
+        "name": "issue:access_token:authorization_code"
+      },
+      "resource": {
+        "type": "audience",
+        "id": "https://eu.example.com/customers"
+      }
+    },
+    {
+      "action": { "name": "read:contacts" },
+      "resource": {
+        "type": "customer_information",
+        "id": "https://example.com/customers"
+      }
+    },
+    {
+      "action": { "name": "read:photos" },
+      "resource": {
+        "type": "customer_information",
+        "id": "https://example.com/customers"
+      }
+    },
+    {
+      "action": { "name": "read:contacts" },
+      "resource": {
+        "type": "customer_information",
+        "id": "https://eu.example.com/customers"
+      }
+    },
+    {
+      "action": { "name": "read:photos" },
+      "resource": {
+        "type": "customer_information",
+        "id": "https://eu.example.com/customers"
+      }
+    }
+  ],
+  "options": { "evaluations_semantic": "execute_all" }
+}
+~~~
+
+The PDP permits both gates and denies one cell, photos at the European
+location.
+
+~~~ json
+{
+  "evaluations": [
+    { "decision": true },
+    { "decision": true },
+    { "decision": true },
+    { "decision": true },
+    { "decision": true },
+    {
+      "decision": false,
+      "context": { "reason_admin": { "403": "residency R-4" } }
+    }
+  ]
+}
+~~~
+
+Three of the four cells survive, and three cells are not a product, so the
+entry cannot reassemble into one. The AS returns two entries of the same
+type, as {{rar-denial}} requires:
+
+~~~ json
+[
+  {
+    "type": "customer_information",
+    "locations": [ "https://example.com/customers" ],
+    "actions": [ "read" ],
+    "datatypes": [ "contacts", "photos" ]
+  },
+  {
+    "type": "customer_information",
+    "locations": [ "https://eu.example.com/customers" ],
+    "actions": [ "read" ],
+    "datatypes": [ "contacts" ]
+  }
+]
+~~~
+
+Both gates permitted, so both targets remain in the audience. Had the second
+gate been denied instead, {{gate-denial}} would have removed that target and
+the AS would have disregarded both evaluations naming it, denied or not,
+leaving the first entry alone and no second entry at all.
+
+# Relationship to Companion Documents {#companions}
+
+This document defines the mapping and the shaping vocabulary, and registers
+short names for the grant types listed in {{iana-actions}}. For a grant whose
+request names a single party, that is everything an AS needs; the client
+credentials and authorization code examples above are complete, and no
+companion document is required to implement them.
+
+A binding is required where a grant family adds structure this document does
+not model. The token exchange family adds two such things: a request names a
+second party, the requesting party, whose authority is separately at stake;
+and several of its members issue an artifact whose own audience differs from
+the audience of the access it describes. Bindings are therefore expected for
+that family - including identity chaining, identity assertion authorization
+grants, and transaction tokens - and a profile describing the use of AuthZEN
+search operations to populate the authorization claims of {{RFC9068}}.
+
+Bindings specify the subject derivation for their grant, any additional
+context keys, the token type short names they register, and any invariants
+of their own that a PDP cannot override.
+
+## Related Work {#related}
+
+Two other efforts place an AuthZEN Policy Decision Point behind an
+authorization server.
+
+{{I-D.brossard-oauth-rar-authzen}} carries an AuthZEN request and response
+inside `authorization_details`, placing the evaluation on the OAuth wire. It
+has expired. This document does not adopt that approach: the evaluation
+stays between the authorization server and its Policy Decision Point, and
+the client sees only an OAuth response. {{rar-tuple}} covers the same
+territory the other way round, deriving the evaluation from the
+authorization details the client already sends rather than asking the client
+to construct one.
+
+{{ARAP}} defines what happens when a Policy Decision Point denies a request
+but marks the denial as requestable: the enforcement point submits an access
+request, an approval is obtained out of band, and a fresh evaluation is
+performed so that the Policy Decision Point remains authoritative at
+enforcement time. That profile deliberately does not bind the loop to OAuth,
+requiring instead that a separate profile define a completion mode
+appropriate to the flow. The AuthZEN Working Group's Access Request OAuth
+Profile supplies that completion mode, and it governs the same moment as
+this document.
+
+The two divide along the value of `decision`. The approval work specifies
+the deny path: a requestable denial becomes an asynchronous approval, and
+issuance follows the re-evaluation. This document specifies the allow path:
+how the evaluation request is formed, and how a permit may narrow what is
+issued. The approval work therefore already establishes that response
+`context` shapes issuance; it does so for approval state, where this
+document does so for the granted authorization.
+
+Because both must construct an evaluation request from an OAuth token
+request, that construction is shared surface, and its treatment in the
+approval profiles is deliberately brief, being incidental to their subject.
+Where the two overlap, this document is intended to supply the detail rather
+than to compete, and aligning the two is expected work.
+
+{{GRANTMGMT}} approaches the same authorization from the other end. Its
+grant query response reports a grant as `scopes`, `claims`, and
+`authorization_details`, which is the set of constraining keys of
+{{shaping}} seen after the fact: this document specifies how a
+Policy Decision Point shapes those at issuance, and grant management
+specifies how a client reads and manages them afterwards. Its `scopes`
+member pairs each scope value with the resource indicators it applies to,
+which is the same per-target scoping the scope tuple of {{scope-tuple}}
+produces. Section 8.2 of that document records that the addressibility of
+individual grant components is unresolved, and the decomposition of
+{{rar-tuple}} bears on it, since a cell of an authorization details entry is
+addressable by construction.
+
+# Security Considerations
+
+## Fail Closed {#fail-closed}
+
+Every failure of the profile - an unreachable PDP, a malformed response, a
+shaping value that violates {{no-broadening}}, an unrecognized `crit`
+member - MUST result in no token being issued. A PDP that cannot be
+consulted is not an authorization to proceed.
+
+Because the PDP is on the token issuance path, its availability becomes the
+AS's availability. Deployments should consider caching of decisions, local
+policy fallback that is explicitly configured rather than implicit, and the
+latency budget of the token endpoint.
+
+## Request Amplification {#amplification}
+
+One token request becomes many evaluations. A client controls the scopes it
+asks for, the targets it names, and the size of every `authorization_details`
+entry, and {{rar-tuple}} turns each entry into the product of its common data
+fields. That product is the legitimate meaning of a RAR entry, not an abuse of
+it; the feature becomes a burden only when it is used to excess. An AS that
+does not bound the fan-out lets an authenticated but unprivileged client
+impose disproportionate work on the PDP, and through the PDP on every other
+tenant of it.
+
+{{residue}} and {{bounded}} are the two controls, and they are independent of
+each other. The first removes what the AS was never going to grant; the second
+caps what remains. An AS SHOULD also track fan-out per client over time. A
+per-request cap does not bound the rate at which maximum-size requests can be
+submitted, and a rate limit does not bound the cost of a single request;
+neither substitutes for the other.
+
+{{AUTHZEN}} Section 11.7 places a matching obligation on the PDP, which
+"SHOULD apply reasonable protections to avoid common attacks tied to request
+payload size, the number of requests ... or memory consumption". An AS MUST
+NOT rely on it. Those protections take the form of the PDP shedding requests,
+and a request the PDP sheds is one the AS must fail closed on ({{fail-closed}}),
+so leaning on them converts an amplification attack into an outage.
+
+## The Policy Decision Point as a Trust Dependency
+
+A PDP that can shape tokens can narrow every grant an AS issues, and a
+compromised PDP can deny service. The constraints in this document bound the
+damage in the other direction: because no shaping key may broaden a grant,
+because `sub`, `aud`, and `cnf` are reserved, and because the AS validates
+every constraining key before applying it, a compromised PDP cannot cause an
+AS to issue a token for a different subject, aimed at a different audience,
+bound to a different key, or bearing a privilege that no evaluation
+considered.
+
+This is why the reservations in {{claims}} are normative rather than
+advisory. An implementation that passed PDP-supplied claims into a token
+without checking them against that list would give the PDP the ability to
+mint arbitrary identities.
+
+## Integrity of the Decision Response
+
+The `crit` mechanism relies on the response arriving intact. An attacker
+able to strip `crit` from a response is also able to change `decision` to
+`true`, so `crit` does not extend the attack surface beyond what transport
+protection between the AS and the PDP must already cover. It is not a
+substitute for that protection, and deployments requiring non-repudiation of
+decisions should use the response signing mechanisms of {{AUTHZEN}}.
+
+## Privacy
+
+Evaluation requests carry subject identifiers, client identifiers, targets,
+and authentication context to the PDP, and do so on every token issuance.
+Where the PDP is operated by a party other than the operator of the AS, this
+is a disclosure of authentication and access patterns for every user of the
+system.
+
+Requiring that identifier transformations be applied before the request is
+constructed ({{subject}}) means that a PDP
+receiving pairwise or pseudonymous identifiers sees only the identifier the
+token itself will carry, rather than a durable global identifier. Deployments
+sensitive to this should prefer such identifiers.
+
+Where `context` conveys authentication context or device posture, deployments
+should include only what their policies actually consume. The design rule of
+{{design-goals}} already bounds how much that ought to be.
+
+# IANA Considerations
+
+This document has no IANA actions. OpenID Foundation registry requests are
+listed in {{oidf-registries}}.
+
+# OpenID Foundation Registry Considerations {#oidf-registries}
+
+## AuthZEN Policy Decision Point Capabilities Registry {#iana-capability}
+
+This specification requests registration of the following PDP capability in
+the AuthZEN Policy Decision Point Capabilities Registry.
+
+Capability Name:
+: `token-issuance`
+
+Capability URN:
+: `urn:openid:authzen:capability:token-issuance`
+
+Capability Description:
+: Support for the OAuth 2.0 token issuance profile, comprising the request
+  mapping and the `issuance` response context vocabulary.
+
+Change Controller:
+: OpenID Foundation AuthZEN Working Group
+
+Specification Document:
+: This document.
+
+The capability URN registered above uses the `urn:openid:authzen:` namespace
+administered by the OpenID Foundation, rather than the `urn:ietf:params:authzen:`
+sub-namespace that {{AUTHZEN}} registers for capabilities. This is an OpenID
+Foundation profile convention, and {{ARAP}} follows it for
+`urn:openid:authzen:capability:access-request`. The `capabilities` array
+remains a list of URNs as defined by {{AUTHZEN}}.
+
+## AuthZEN Token Issuance Entity Types Registry {#iana-types}
+
+This specification requests creation of a new registry: the AuthZEN Token
+Issuance Entity Types registry, which tracks the `type` values this profile
+gives the subject and resource of an issuance evaluation. Registration policy
+is Specification Required. Initial entries:
+
+| Type | Applies to | Description |
+|---|---|---|
+| `user` | subject | A natural person |
+| `client` | subject | An OAuth client acting on its own behalf |
+| `workload` | subject | A non-human software identity |
+| `audience` | resource | The audience of the access being granted |
+
+Change Controller for all initial entries: OpenID Foundation AuthZEN Working
+Group. Specification Document for all initial entries: This document.
+
+## AuthZEN Token Issuance Action Names Registry {#iana-actions}
+
+This specification requests creation of a new registry: the AuthZEN Token
+Issuance Action Names registry, which tracks the two short-name vocabularies
+from which action names in the reserved `issue:` space are composed.
+Registration policy is Specification Required.
+
+A gate action name is `issue:<token-type>:<grant-type>`, so the registry
+grows with the number of token types plus the number of grant types, not
+with their product. The combinations that are meaningful in a deployment are
+a matter of policy, not of registration.
+
+Every short name MUST match `[a-z][a-z0-9_]{0,30}`, and a composed action
+name MUST NOT exceed 50 characters. {{action-portability}} gives the reason:
+these bounds are what let the name be transformed mechanically into a
+relation identifier that relationship-based engines accept. Registrants
+should note that the hyphen is excluded deliberately, and that a short name
+therefore differs from the corresponding URI wherever that URI contains one.
+
+Token type short names, initially:
+
+| Short name | Token type |
+|---|---|
+| `access_token` | `urn:ietf:params:oauth:token-type:access_token` |
+| `refresh_token` | `urn:ietf:params:oauth:token-type:refresh_token` |
+| `id_token` | `urn:ietf:params:oauth:token-type:id_token` |
+
+Grant type short names, initially:
+
+| Short name | Grant type |
+|---|---|
+| `authorization_code` | `authorization_code` |
+| `client_credentials` | `client_credentials` |
+| `refresh_token` | `refresh_token` |
+| `token_exchange` | `urn:ietf:params:oauth:grant-type:token-exchange` |
+| `device_code` | `urn:ietf:params:oauth:grant-type:device_code` |
+| `jwt_bearer` | `urn:ietf:params:oauth:grant-type:jwt-bearer` |
+| `saml2_bearer` | `urn:ietf:params:oauth:grant-type:saml2-bearer` |
+
+Change Controller for all initial entries: OpenID Foundation AuthZEN Working
+Group. Specification Document for all initial entries: This document.
+
+Registrations MUST give the URI or parameter value the short name
+corresponds to, and MUST state which of the two vocabularies they join.
+Names outside the `issue:` prefix are not registered here, since scope values
+and the action names of {{rar-tuple}} are carried verbatim and are not
+registered vocabularies.
+
+This document reserves one further name outside the `issue:` prefix:
+`authorization_detail`, which {{rar-tuple}} substitutes for the action of an
+authorization details entry that names none.
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+This work was motivated in part by Karl McGuinness, whose initiative to
+bridge OAuth and AuthZEN - in {{ARAP}} and its OAuth completion mode -
+established that a Policy Decision Point belongs behind the token endpoint,
+and that the response of such a Policy Decision Point may legitimately shape
+what is issued. This document takes up the other half of that decision.
+
+Thanks also to the participants in the OpenID AuthZEN interoperability
+events, whose December 2025 identity provider scenario demonstrated AuthZEN
+search operations populating token claims, and to the members of the AuthZEN
+Working Group and the OAuth Working Group.
+
+# Document History
+{:numbered="false"}
+
+Draft 1 continues the individual Internet-Draft
+`draft-gazitt-oauth-authzen-issuance`, whose `-01` made the changes below.
+
+## Since -00
+{:numbered="false"}
+
+* A request may now name several issuance targets. The single-target MUST in
+  {{resource}} becomes a SHOULD inherited from {{RFC8707}} Section 5 and
+  {{RFC9700}} Section 4.10.2, and {{several-targets}} says how tuples are
+  formed per target, how a denied gate removes one, and why a scope survives
+  only where it was permitted at every surviving target.
+* Requested `authorization_details` now reach the PDP. {{rar-tuple}}
+  decomposes an entry along the product of {{RFC9396}} Section 2.2 into one
+  evaluation per location, action, and datatype, with the datatype carried as
+  a trailing segment of `action.name`.
+* {{residue}} orders the AS's own reductions before the PDP call, so the batch
+  carries only what the AS would otherwise grant.
+* {{bounded}} requires an AS to bound the size of the batch without naming a
+  bound, and {{amplification}} covers the attack.
+* `crit` is unilateral. The enforcement point capability declaration and the
+  precondition that gated `crit` on it are removed, so this profile no longer
+  uses `context.issuance` on the request leg at all.
+* The structural check of {{rar-response}} tests a returned entry against a
+  single covering request entry rather than against the union of the
+  same-type entries, and a member absent from the request entry no longer
+  causes rejection.
+* Added worked examples of both authorization details shapes, cross-references
+  between the rules and the examples that exercise them, and a Related Work
+  paragraph on {{GRANTMGMT}}.


### PR DESCRIPTION
This adds the three drafts the WG adopted on 2026-08-27, converted from
their IETF individual-submission form into the repo's house style.

- `profiles/authzen-oauth/authzen-oauth-token-issuance-1_0.md` - the
  framework. Maps an OAuth token request onto an AuthZEN evaluation, and
  defines the `issuance` response context vocabulary the AS uses to shape
  what it issues.
- `profiles/authzen-oauth/authzen-oauth-token-exchange-1_0.md` - the
  binding to RFC 8693, covering delegation, impersonation, identity
  chaining, ID-JAG and Transaction Tokens.
- `profiles/authzen-oauth/authzen-oauth-authorization-claims-1_0.md` -
  sources the `groups`, `roles` and `entitlements` claims of a JWT access
  token from AuthZEN Resource Search.

All three were posted at `-01` on the datatracker and the markdown here is
that text with the frontmatter and IANA sections changed, not a rewrite:

- https://datatracker.ietf.org/doc/draft-gazitt-oauth-authzen-issuance/
- https://datatracker.ietf.org/doc/draft-gazitt-oauth-authzen-token-exchange/
- https://datatracker.ietf.org/doc/draft-gazitt-oauth-authzen-claims/

What changed in the conversion:

- Frontmatter follows the ARAP/COAZ pattern - `ipr: none`, no
  `submissiontype`/`area`/`venue`, `workgroup: OpenID AuthZEN`, title
  suffixed `- Draft 1`.
- `IANA Considerations` now says the document has no IANA actions and
  points at a separate `OpenID Foundation Registry Considerations`
  section, the same split ARAP uses. The PDP capability moved from
  `urn:ietf:params:authzen:token-issuance` to
  `urn:openid:authzen:capability:token-issuance`, matching
  `urn:openid:authzen:capability:access-request`. New registries are
  Specification Required.
- `profiles/Makefile` and `.github/workflows/jekyll-gh-pages.yml` both
  carry a hardcoded per-document list, so all three are added to each.
  Without the workflow change the documents build locally but never
  publish.
- README gets a section per document, in the existing format.

All three build clean. The only xml2rfc warning is the missing
`submissionType`, which ARAP emits too.