### PR TITLE
Specify response shape when evaluations array is absent or empty

### DIFF
--- a/api/authorization-api-1_0.md
+++ b/api/authorization-api-1_0.md
@@ -470,7 +470,7 @@ The Access Evaluation API Request builds on the information model presented in {
 
 To send multiple access evaluation requests in a single message, the PEP MAY add an `evaluations` key to the request. The `evaluations` key is an array which contains a list of objects, each typed as the object as defined in the Access Evaluation Request ({{access-evaluation-request}}), and specifying a discrete request.
 
-If an `evaluations` array is NOT present or is empty, the Access Evaluations Request behaves in a backwards-compatible manner with the (single) Access Evaluation API Request ({{access-evaluation-request}}).
+If an `evaluations` array is NOT present or is empty, the Access Evaluations Request behaves in a backwards-compatible manner with the (single) Access Evaluation API Request ({{access-evaluation-request}}), and the PDP responds with an Access Evaluation Response ({{access-evaluation-response}}) rather than an Access Evaluations Response ({{access-evaluations-response}}).
 
 If an `evaluations` array IS present and contains one or more objects, these form distinct requests that the PDP will evaluate. These requests are independent from each other, and may be executed sequentially or in parallel, left to the discretion of each implementation.
 


### PR DESCRIPTION
Fixes #639

Section 7.1 says an Access Evaluations Request with no `evaluations` array (or an empty one) behaves like a single Access Evaluation Request, but neither 7.1 nor 7.2 states what the response looks like. The only hint is the RECOMMENDED omission of `decision` in 7.2, which is conditioned on the array being present.

This adds one clause to the 7.1 sentence: the PDP responds with an Access Evaluation Response rather than an Access Evaluations Response. This matches what the certification scenario already requires in c-3-4-2 and c-3-4-3, and is consistent with c-3-3-1 (response array length equals request array length), which excludes a one-element `evaluations` envelope for the empty-array case.